### PR TITLE
Replaced std::multimap in reco::IsoDeposit

### DIFF
--- a/DataFormats/RecoCandidate/interface/IsoDeposit.h
+++ b/DataFormats/RecoCandidate/interface/IsoDeposit.h
@@ -25,7 +25,6 @@
 #include <vector>
 #include <algorithm>
 #include <typeinfo>
-#include <atomic>
 
 namespace reco {
   namespace isodeposit {
@@ -70,10 +69,10 @@ namespace reco {
 
     //! Constructor
     IsoDeposit(double eta = 0, double phi = 0);
-    IsoDeposit(const Direction& candDirection);
+    explicit IsoDeposit(const Direction& candDirection);
 
     //! Destructor
-    virtual ~IsoDeposit(){};
+    ~IsoDeposit(){};
 
     //! Get direction of isolation cone
     const Direction& direction() const { return theDirection; }
@@ -171,8 +170,8 @@ namespace reco {
           : parent_(parent), it_(it), cache_(), cacheReady_(false) {}
       const reco::IsoDeposit* parent_;
       IsoDeposit::DepositsMultimap::const_iterator it_;
-      CMS_THREAD_SAFE mutable Direction cache_;
-      mutable std::atomic<bool> cacheReady_;
+      CMS_SA_ALLOW mutable Direction cache_;
+      CMS_SA_ALLOW mutable bool cacheReady_;
     };
     const_iterator begin() const { return const_iterator(this, theDeposits.begin()); }
     const_iterator end() const { return const_iterator(this, theDeposits.end()); }

--- a/DataFormats/RecoCandidate/src/IsoDeposit.cc
+++ b/DataFormats/RecoCandidate/src/IsoDeposit.cc
@@ -18,12 +18,14 @@ IsoDeposit::IsoDeposit(double eta, double phi) : theDirection(Direction(eta, phi
 
 void IsoDeposit::addDeposit(double dr, double value) {
   Distance relDir = {float(dr), 0.f};
-  theDeposits.insert(std::make_pair(relDir, value));
+  theDeposits.insert(std::lower_bound(theDeposits.begin(), theDeposits.end(), relDir, Compare()),
+                     std::make_pair(relDir, value));
 }
 
 void IsoDeposit::addDeposit(const Direction& depDir, double deposit) {
   Distance relDir = depDir - theDirection;
-  theDeposits.insert(std::make_pair(relDir, deposit));
+  theDeposits.insert(std::lower_bound(theDeposits.begin(), theDeposits.end(), relDir, Compare()),
+                     std::make_pair(relDir, deposit));
 }
 
 double IsoDeposit::depositWithin(double coneSize, const Vetos& vetos, bool skipDepositVeto) const {
@@ -49,7 +51,7 @@ std::pair<double, int> IsoDeposit::depositAndCountWithin(double coneSize,
 
   Distance maxDistance = {float(coneSize), 999.f};
   typedef DepositsMultimap::const_iterator IM;
-  IM imLoc = theDeposits.upper_bound(maxDistance);
+  IM imLoc = std::upper_bound(theDeposits.begin(), theDeposits.end(), maxDistance, Compare());
   for (IM im = theDeposits.begin(); im != imLoc; ++im) {
     bool vetoed = false;
     for (IV iv = allVetos.begin(); iv < ivEnd; ++iv) {
@@ -107,7 +109,7 @@ std::pair<double, int> IsoDeposit::depositAndCountWithin(double coneSize,
 
   Distance maxDistance = {float(coneSize), 999.f};
   typedef DepositsMultimap::const_iterator IM;
-  IM imLoc = theDeposits.upper_bound(maxDistance);
+  IM imLoc = std::upper_bound(theDeposits.begin(), theDeposits.end(), maxDistance, Compare());
   for (IM im = theDeposits.begin(); im != imLoc; ++im) {
     bool vetoed = false;
     Direction dirDep = theDirection + im->first;
@@ -156,7 +158,7 @@ double IsoDeposit::nearestDR(double coneSize, const AbsVetos& vetos, bool skipDe
 
   Distance maxDistance = {float(coneSize), 999.f};
   typedef DepositsMultimap::const_iterator IM;
-  IM imLoc = theDeposits.upper_bound(maxDistance);
+  IM imLoc = std::upper_bound(theDeposits.begin(), theDeposits.end(), maxDistance, Compare());
   for (IM im = theDeposits.begin(); im != imLoc; ++im) {
     bool vetoed = false;
     Direction dirDep = theDirection + im->first;

--- a/DataFormats/RecoCandidate/src/classes_def.xml
+++ b/DataFormats/RecoCandidate/src/classes_def.xml
@@ -114,7 +114,8 @@
   <class name="edm::reftobase::VectorHolder<reco::Candidate, reco::RecoEcalCandidateRefVector>" />
   <class name="edm::reftobase::RefVectorHolder<reco::RecoEcalCandidateRefVector>" />
 
-  <class name="reco::IsoDeposit" ClassVersion="10">
+  <class name="reco::IsoDeposit" ClassVersion="11">
+   <version ClassVersion="11" checksum="3010914680"/>
    <version ClassVersion="10" checksum="2477314412"/>
   </class>
   <class name="reco::IsoDeposit::const_iterator" ClassVersion="10">


### PR DESCRIPTION
#### PR description:

- changed std::multimap to std::vector<std::pair<>> and use ROOT auto schema evolution to handle reading back old files.
- fixed some issues with IsoDeposit

#### PR validation:

In bare ROOT read back 
```
recoIsoDepositedmValueMap_muIsoDepositJets__RECO.obj.values_.theDeposits
```
values in an unmodified work area and an area with these changes. The values shown by `Events.Scan` were identical.