### PR TITLE
Switch unsigned long long for uint64_t in reco::PFCandidate

### DIFF
--- a/DataFormats/ParticleFlowCandidate/interface/PFCandidate.h
+++ b/DataFormats/ParticleFlowCandidate/interface/PFCandidate.h
@@ -550,7 +550,7 @@ namespace reco {
 
     const edm::EDProductGetter* getter_;  //transient
     unsigned short storedRefsBitPattern_;
-    std::vector<unsigned long long> refsInfo_;
+    std::vector<uint64_t> refsInfo_;
     std::vector<const void*> refsCollectionCache_;
 
     /// timing information (valid if timeError_ >= 0)

--- a/DataFormats/ParticleFlowCandidate/src/classes_def.xml
+++ b/DataFormats/ParticleFlowCandidate/src/classes_def.xml
@@ -1,6 +1,7 @@
 <lcgdict>
 
-   <class name="reco::PFCandidate" ClassVersion="20">
+   <class name="reco::PFCandidate" ClassVersion="21">
+    <version ClassVersion="21" checksum="3100624205"/>
     <version ClassVersion="20" checksum="2748489940"/>
     <version ClassVersion="19" checksum="2990582232"/>
     <version ClassVersion="18" checksum="910857761"/>
@@ -54,7 +55,8 @@
   <class name="edm::PtrVector<reco::PFCandidate> "/>
   <class name="edm::Wrapper<edm::PtrVector<reco::PFCandidate> >"/>
 
-  <class name="reco::IsolatedPFCandidate"  ClassVersion="16">
+  <class name="reco::IsolatedPFCandidate"  ClassVersion="17">
+   <version ClassVersion="17" checksum="3951723310"/>
    <version ClassVersion="16" checksum="2274533749"/>
    <version ClassVersion="15" checksum="3042264953"/>
    <version ClassVersion="14" checksum="207328514"/>
@@ -70,7 +72,8 @@
   <class name="reco::IsolatedPFCandidateRefVector"/>
   <class name="reco::IsolatedPFCandidatePtr"/>
 
-  <class name="reco::PileUpPFCandidate"  ClassVersion="16">
+  <class name="reco::PileUpPFCandidate"  ClassVersion="17">
+   <version ClassVersion="17" checksum="1635014507"/>
    <version ClassVersion="16" checksum="3331568330"/>
    <version ClassVersion="15" checksum="953549166"/>
    <version ClassVersion="14" checksum="4065938015"/>


### PR DESCRIPTION
This was an issue for `pat::Electron` member `vector<reco::PFCandidate> pfCandidate_`, however it appears in MiniAOD the embedded pfCandidate is not stored. We may have to check an AOD file to find full `reco::PFCandidate` objects for testing.