### PR TITLE
RefToBase to Ptr conversion for pat::TriggerObjectStandAlone

### DIFF
--- a/DataFormats/Common/interface/RefToBaseToPtr.h
+++ b/DataFormats/Common/interface/RefToBaseToPtr.h
@@ -6,8 +6,6 @@
 Ref: A function template for conversion from RefToBase to Ptr
 
 ----------------------------------------------------------------------*/
-/*
-    ----------------------------------------------------------------------*/
 
 #include "DataFormats/Common/interface/RefToBase.h"
 #include "DataFormats/Common/interface/Ptr.h"
@@ -43,7 +41,6 @@ namespace edm {
       // by construction would be persistent
       return Ptr<T>();
     } else {
-      //Another thread could change this value so get only once
       EDProductGetter const* getter = ref.productGetter();
       if (getter) {
         return Ptr<T>(ref.id(), ref.key(), getter);

--- a/DataFormats/Common/interface/RefToBaseToPtr.h
+++ b/DataFormats/Common/interface/RefToBaseToPtr.h
@@ -1,0 +1,36 @@
+#ifndef DataFormats_Common_RefToBaseToPtr_h
+#define DataFormats_Common_RefToBaseToPtr_h
+
+/*----------------------------------------------------------------------
+  
+Ref: A function template for conversion from RefToBase to Ptr
+
+----------------------------------------------------------------------*/
+/*
+    ----------------------------------------------------------------------*/
+
+#include "DataFormats/Common/interface/RefToBase.h"
+#include "DataFormats/Common/interface/Ptr.h"
+
+namespace edm {
+  template <typename T>
+  Ptr<T> refToBaseToPtr(RefToBase<T> const& ref) {
+    if (ref.isNull()) {
+      return Ptr<T>();
+    }
+    if (ref.isTransient()) {
+      return Ptr<T>(ref.get(), ref.key());
+    } else {
+      //Another thread could change this value so get only once
+      EDProductGetter const* getter = ref.productGetter();
+      if (getter) {
+        return Ptr<T>(ref.id(), ref.key(), getter);
+      }
+    }
+    // If this is called in an iorule outside the framework, we cannot call
+    // ref.get() but since the Ptr will be able to get it later anyway, we can
+    // fill with a nullptr for now
+    return Ptr<T>(ref.id(), static_cast<const T*>(nullptr), ref.key());
+  }
+}  // namespace edm
+#endif

--- a/DataFormats/Common/interface/RefToBaseToPtr.h
+++ b/DataFormats/Common/interface/RefToBaseToPtr.h
@@ -29,7 +29,7 @@ namespace edm {
   }
 
   /*
-   * Do not use this ouside an ioread rule in classes_def.xml
+   * Do not use this outside an ioread rule in classes_def.xml
    */
   template <typename T>
   Ptr<T> refToBaseToPtr_ioread(RefToBase<T> const& ref) {

--- a/DataFormats/Common/interface/RefToBaseToPtr.h
+++ b/DataFormats/Common/interface/RefToBaseToPtr.h
@@ -27,9 +27,32 @@ namespace edm {
         return Ptr<T>(ref.id(), ref.key(), getter);
       }
     }
+    return Ptr<T>(ref.id(), ref.get(), ref.key());
+  }
+
+  /*
+   * Do not use this ouside an ioread rule in classes_def.xml
+   */
+  template <typename T>
+  Ptr<T> refToBaseToPtr_ioread(RefToBase<T> const& ref) {
+    if (ref.isNull()) {
+      return Ptr<T>();
+    }
+    if (ref.isTransient()) {
+      // This is a logic error, any ref being deserialized
+      // by construction would be persistent
+      return Ptr<T>();
+    } else {
+      //Another thread could change this value so get only once
+      EDProductGetter const* getter = ref.productGetter();
+      if (getter) {
+        return Ptr<T>(ref.id(), ref.key(), getter);
+      }
+    }
     // If this is called in an iorule outside the framework, we cannot call
-    // ref.get() but since the Ptr will be able to get it later anyway, we can
-    // fill with a nullptr for now
+    // ref.get(), but since outside the framework we can never fetch the ref,
+    // the Ptr will only be useful if accessed later from inside the framework.
+    // We can fill with a nullptr for now
     return Ptr<T>(ref.id(), static_cast<const T*>(nullptr), ref.key());
   }
 }  // namespace edm

--- a/DataFormats/Common/interface/RefToBaseToPtr.h
+++ b/DataFormats/Common/interface/RefToBaseToPtr.h
@@ -27,30 +27,5 @@ namespace edm {
     }
     return Ptr<T>(ref.id(), ref.get(), ref.key());
   }
-
-  /*
-   * Do not use this outside an ioread rule in classes_def.xml
-   */
-  template <typename T>
-  Ptr<T> refToBaseToPtr_ioread(RefToBase<T> const& ref) {
-    if (ref.isNull()) {
-      return Ptr<T>();
-    }
-    if (ref.isTransient()) {
-      // This is a logic error, any ref being deserialized
-      // by construction would be persistent
-      return Ptr<T>();
-    } else {
-      EDProductGetter const* getter = ref.productGetter();
-      if (getter) {
-        return Ptr<T>(ref.id(), ref.key(), getter);
-      }
-    }
-    // If this is called in an iorule outside the framework, we cannot call
-    // ref.get(), but since outside the framework we can never fetch the ref,
-    // the Ptr will only be useful if accessed later from inside the framework.
-    // We can fill with a nullptr for now
-    return Ptr<T>(ref.id(), static_cast<const T*>(nullptr), ref.key());
-  }
 }  // namespace edm
 #endif

--- a/DataFormats/Common/interface/RefToBaseToPtr_ioread.h
+++ b/DataFormats/Common/interface/RefToBaseToPtr_ioread.h
@@ -1,0 +1,37 @@
+#ifndef DataFormats_Common_RefToBaseToPtr_ioread_h
+#define DataFormats_Common_RefToBaseToPtr_ioread_h
+
+/*----------------------------------------------------------------------
+  
+Ref: A function template for conversion from RefToBase to Ptr for use
+in ROOT ioread rules for schema migration
+
+----------------------------------------------------------------------*/
+
+#include "DataFormats/Common/interface/RefToBase.h"
+#include "DataFormats/Common/interface/Ptr.h"
+
+namespace edm {
+  template <typename T>
+  Ptr<T> refToBaseToPtr_ioread(RefToBase<T> const& ref) {
+    if (ref.isNull()) {
+      return Ptr<T>();
+    }
+    if (ref.isTransient()) {
+      // This is a logic error, any ref being deserialized
+      // by construction would be persistent
+      return Ptr<T>();
+    } else {
+      EDProductGetter const* getter = ref.productGetter();
+      if (getter) {
+        return Ptr<T>(ref.id(), ref.key(), getter);
+      }
+    }
+    // If this is called in an iorule outside the framework, we cannot call
+    // ref.get(), but since outside the framework we can never fetch the ref,
+    // the Ptr will only be useful if accessed later from inside the framework.
+    // We can fill with a nullptr for now
+    return Ptr<T>(ref.id(), static_cast<const T*>(nullptr), ref.key());
+  }
+}  // namespace edm
+#endif

--- a/DataFormats/PatCandidates/interface/TriggerObject.h
+++ b/DataFormats/PatCandidates/interface/TriggerObject.h
@@ -53,7 +53,7 @@ namespace pat {
     /// Reference to trigger object,
     /// meant for 'l1extra' particles to access their additional functionalities,
     /// empty otherwise
-    reco::CandidateBaseRef refToOrig_;
+    reco::CandidatePtr refToOrig_;
 
   public:
     /// Constructors and Destructor
@@ -117,37 +117,39 @@ namespace pat {
     /// Special methods for 'l1extra' particles
 
     /// General getters
-    const reco::CandidateBaseRef& origObjRef() const { return refToOrig_; };
     const reco::Candidate* origObjCand() const { return refToOrig_.get(); };
     /// Getters specific to the 'l1extra' particle type for
     /// - EM
-    const l1extra::L1EmParticleRef origL1EmRef() const;
     const L1GctEmCand* origL1GctEmCand() const {
-      return origL1EmRef().isNonnull() ? origL1EmRef()->gctEmCand() : nullptr;
+      auto* cand = dynamic_cast<const l1extra::L1EmParticle*>(origObjCand());
+      return cand ? cand->gctEmCand() : nullptr;
     };
     /// - EtMiss
-    const l1extra::L1EtMissParticleRef origL1EtMissRef() const;
     const L1GctEtMiss* origL1GctEtMiss() const {
-      return origL1EtMissRef().isNonnull() ? origL1EtMissRef()->gctEtMiss() : nullptr;
+      auto* cand = dynamic_cast<const l1extra::L1EtMissParticle*>(origObjCand());
+      return cand ? cand->gctEtMiss() : nullptr;
     };
     const L1GctEtTotal* origL1GctEtTotal() const {
-      return origL1EtMissRef().isNonnull() ? origL1EtMissRef()->gctEtTotal() : nullptr;
+      auto* cand = dynamic_cast<const l1extra::L1EtMissParticle*>(origObjCand());
+      return cand ? cand->gctEtTotal() : nullptr;
     };
     const L1GctHtMiss* origL1GctHtMiss() const {
-      return origL1EtMissRef().isNonnull() ? origL1EtMissRef()->gctHtMiss() : nullptr;
+      auto* cand = dynamic_cast<const l1extra::L1EtMissParticle*>(origObjCand());
+      return cand ? cand->gctHtMiss() : nullptr;
     };
     const L1GctEtHad* origL1GctEtHad() const {
-      return origL1EtMissRef().isNonnull() ? origL1EtMissRef()->gctEtHad() : nullptr;
+      auto* cand = dynamic_cast<const l1extra::L1EtMissParticle*>(origObjCand());
+      return cand ? cand->gctEtHad() : nullptr;
     };
     /// - Jet
-    const l1extra::L1JetParticleRef origL1JetRef() const;
     const L1GctJetCand* origL1GctJetCand() const {
-      return origL1JetRef().isNonnull() ? origL1JetRef()->gctJetCand() : nullptr;
+      auto* cand = dynamic_cast<const l1extra::L1JetParticle*>(origObjCand());
+      return cand ? cand->gctJetCand() : nullptr;
     };
     /// - Muon
-    const l1extra::L1MuonParticleRef origL1MuonRef() const;
     const L1MuGMTExtendedCand* origL1GmtMuonCand() const {
-      return origL1MuonRef().isNonnull() ? &(origL1MuonRef()->gmtMuonCand()) : nullptr;
+      auto* cand = dynamic_cast<const l1extra::L1MuonParticle*>(origObjCand());
+      return cand ? &(cand->gmtMuonCand()) : nullptr;
     };
 
     /// Special methods for the cut string parser

--- a/DataFormats/PatCandidates/src/TriggerObject.cc
+++ b/DataFormats/PatCandidates/src/TriggerObject.cc
@@ -3,6 +3,7 @@
 
 #include "DataFormats/PatCandidates/interface/TriggerObject.h"
 
+#include "DataFormats/Common/interface/RefToBaseToPtr.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 
 using namespace pat;
@@ -25,7 +26,7 @@ TriggerObject::TriggerObject(const reco::LeafCandidate& leafCand) : reco::LeafCa
 
 // Constructors from base candidate reference (for 'l1extra' particles)
 TriggerObject::TriggerObject(const reco::CandidateBaseRef& candRef)
-    : reco::LeafCandidate(*candRef), refToOrig_(candRef) {
+    : reco::LeafCandidate(*candRef), refToOrig_(edm::refToBaseToPtr(candRef)) {
   triggerObjectTypes_.clear();
 }
 
@@ -79,56 +80,3 @@ bool TriggerObject::hasTriggerObjectType(trigger::TriggerObjectType triggerObjec
   return false;
 }
 
-// Special methods for 'l1extra' particles
-
-// Getters specific to the 'l1extra' particle types
-// Exceptions of type 'edm::errors::InvalidReference' are thrown,
-// if wrong particle type is requested
-
-// EM
-const l1extra::L1EmParticleRef TriggerObject::origL1EmRef() const {
-  l1extra::L1EmParticleRef l1Ref;
-  try {
-    l1Ref = origObjRef().castTo<l1extra::L1EmParticleRef>();
-  } catch (edm::Exception const& X) {
-    if (X.categoryCode() != edm::errors::InvalidReference)
-      throw X;
-  }
-  return l1Ref;
-}
-
-// EtMiss
-const l1extra::L1EtMissParticleRef TriggerObject::origL1EtMissRef() const {
-  l1extra::L1EtMissParticleRef l1Ref;
-  try {
-    l1Ref = origObjRef().castTo<l1extra::L1EtMissParticleRef>();
-  } catch (edm::Exception const& X) {
-    if (X.categoryCode() != edm::errors::InvalidReference)
-      throw X;
-  }
-  return l1Ref;
-}
-
-// Jet
-const l1extra::L1JetParticleRef TriggerObject::origL1JetRef() const {
-  l1extra::L1JetParticleRef l1Ref;
-  try {
-    l1Ref = origObjRef().castTo<l1extra::L1JetParticleRef>();
-  } catch (edm::Exception const& X) {
-    if (X.categoryCode() != edm::errors::InvalidReference)
-      throw X;
-  }
-  return l1Ref;
-}
-
-// Muon
-const l1extra::L1MuonParticleRef TriggerObject::origL1MuonRef() const {
-  l1extra::L1MuonParticleRef l1Ref;
-  try {
-    l1Ref = origObjRef().castTo<l1extra::L1MuonParticleRef>();
-  } catch (edm::Exception const& X) {
-    if (X.categoryCode() != edm::errors::InvalidReference)
-      throw X;
-  }
-  return l1Ref;
-}

--- a/DataFormats/PatCandidates/src/classes_def_trigger.xml
+++ b/DataFormats/PatCandidates/src/classes_def_trigger.xml
@@ -7,8 +7,8 @@
    <version ClassVersion="11" checksum="2574350865"/>
    <version ClassVersion="10" checksum="2299474032"/>
   </class>
-  <ioread sourceClass="pat::TriggerObject" version="[-12]" source="reco::CandidateBaseRef refToOrig_" targetClass="reco::CandidatePtr" target="refToOrig_">
-    <![CDATA[ refToOrig_ = edm::RefToBaseToPtr(onfile.refToOrig_); ]]>
+  <ioread sourceClass="pat::TriggerObject" version="[-12]" source="reco::CandidateBaseRef refToOrig_" targetClass="pat::TriggerObject" target="refToOrig_">
+    <![CDATA[ refToOrig_ = edm::refToBaseToPtr(onfile.refToOrig_); ]]>
    </ioread>
   <class name="std::vector&lt;pat::TriggerObject&gt;" />
   <class name="std::vector&lt;pat::TriggerObject&gt;::const_iterator" />

--- a/DataFormats/PatCandidates/src/classes_def_trigger.xml
+++ b/DataFormats/PatCandidates/src/classes_def_trigger.xml
@@ -8,7 +8,7 @@
    <version ClassVersion="10" checksum="2299474032"/>
   </class>
   <ioread sourceClass="pat::TriggerObject" version="[-12]" source="reco::CandidateBaseRef refToOrig_" targetClass="pat::TriggerObject" target="refToOrig_">
-    <![CDATA[ refToOrig_ = edm::refToBaseToPtr(onfile.refToOrig_); ]]>
+    <![CDATA[ refToOrig_ = edm::refToBaseToPtr_ioread(onfile.refToOrig_); ]]>
    </ioread>
   <class name="std::vector&lt;pat::TriggerObject&gt;" />
   <class name="std::vector&lt;pat::TriggerObject&gt;::const_iterator" />

--- a/DataFormats/PatCandidates/src/classes_def_trigger.xml
+++ b/DataFormats/PatCandidates/src/classes_def_trigger.xml
@@ -1,11 +1,15 @@
 <lcgdict>
  <selection>
 
-  <class name="pat::TriggerObject"  ClassVersion="12">
+  <class name="pat::TriggerObject"  ClassVersion="13">
+   <version ClassVersion="13" checksum="1564486686"/>
    <version ClassVersion="12" checksum="2628734905"/>
    <version ClassVersion="11" checksum="2574350865"/>
    <version ClassVersion="10" checksum="2299474032"/>
   </class>
+  <ioread sourceClass="pat::TriggerObject" version="[-12]" source="reco::CandidateBaseRef refToOrig_" targetClass="reco::CandidatePtr" target="refToOrig_">
+    <![CDATA[ refToOrig_ = edm::RefToBaseToPtr(onfile.refToOrig_); ]]>
+   </ioread>
   <class name="std::vector&lt;pat::TriggerObject&gt;" />
   <class name="std::vector&lt;pat::TriggerObject&gt;::const_iterator" />
   <class name="edm::Wrapper&lt;std::vector&lt;pat::TriggerObject&gt; &gt;" />
@@ -26,7 +30,8 @@
   <class name="std::map&lt;std::string, edm::RefProd&lt;edm::Association&lt;std::vector&lt;pat::TriggerObject&gt; &gt; &gt; &gt;::const_iterator" />
   <class name="edm::Wrapper&lt;std::map&lt;std::string, edm::RefProd&lt;edm::Association&lt;std::vector&lt;pat::TriggerObject&gt; &gt; &gt; &gt; &gt;" />
 
-  <class name="pat::TriggerObjectStandAlone"  ClassVersion="14">
+  <class name="pat::TriggerObjectStandAlone"  ClassVersion="15">
+   <version ClassVersion="15" checksum="3059129506"/>
    <version ClassVersion="14" checksum="2704342787"/>
    <version ClassVersion="13" checksum="54935316"/>
    <version ClassVersion="12" checksum="2923001116"/>

--- a/DataFormats/PatCandidates/src/classes_trigger.h
+++ b/DataFormats/PatCandidates/src/classes_trigger.h
@@ -2,6 +2,7 @@
 #include "DataFormats/Common/interface/Association.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 #include "DataFormats/Common/interface/PtrVector.h"
+#include "DataFormats/Common/interface/RefToBaseToPtr.h"
 
 #include "DataFormats/PatCandidates/interface/TriggerObjectStandAlone.h"
 #include "DataFormats/PatCandidates/interface/TriggerEvent.h"

--- a/DataFormats/PatCandidates/src/classes_trigger.h
+++ b/DataFormats/PatCandidates/src/classes_trigger.h
@@ -2,7 +2,7 @@
 #include "DataFormats/Common/interface/Association.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 #include "DataFormats/Common/interface/PtrVector.h"
-#include "DataFormats/Common/interface/RefToBaseToPtr.h"
+#include "DataFormats/Common/interface/RefToBaseToPtr_ioread.h"
 
 #include "DataFormats/PatCandidates/interface/TriggerObjectStandAlone.h"
 #include "DataFormats/PatCandidates/interface/TriggerEvent.h"


### PR DESCRIPTION
**Description:**
Implemented two templated methods: `refToBaseToPtr` for use in class constructors, etc., where the desire is to keep the RefToBase API available, and then `refToBaseToPtr_ioread` to be used exclusively in `ioread` rules to do schema migration of data written with the old type.

**Validation:**
Managed to forward-copy the data products:
```
$ edmCopyPickMerge inputFiles=file:../../data/ul17ttsemi_miniaod.root outputFile=../../data/ul17ttsemi_miniaod_copy.root
20-Nov-2023 17:05:19 CST  Initiating request to open file file:../../data/ul17ttsemi_miniaod.root
20-Nov-2023 17:05:24 CST  Successfully opened file file:../../data/ul17ttsemi_miniaod.root
%MSG-w FastCloningDisabled:  AfterModBeginStream 20-Nov-2023 17:05:25 CST  BeforeEvents
Fast copying of file file:../../data/ul17ttsemi_miniaod.root to file ../../data/ul17ttsemi_miniaod_copy.root is disabled because:
The format of a data product has changed.

%MSG
Begin processing the 1st record. Run 1, Event 66298012, LumiSection 66299 on stream 0 at 20-Nov-2023 17:05:25.366 CST
Begin processing the 2nd record. Run 1, Event 66298002, LumiSection 66299 on stream 0 at 20-Nov-2023 17:05:25.805 CST
...
```
but I cannot verify if non-null `origObjCand()` is working, since it appears the `PATTriggerProducer` default value for `saveL1Refs` is false, and this is not overridden in MiniAOD production (despite l1extra being in MiniAOD)