### PR TITLE
Removed embedded BaseTagInfo in pat::Jet

### DIFF
--- a/DataFormats/PatCandidates/interface/Jet.h
+++ b/DataFormats/PatCandidates/interface/Jet.h
@@ -631,8 +631,7 @@ namespace pat {
 
     std::vector<std::pair<std::string, float> > pairDiscriVector_;
     std::vector<std::string> tagInfoLabels_;
-    edm::OwnVector<reco::BaseTagInfo> tagInfos_;  // Compatibility embedding
-    TagInfoFwdPtrCollection tagInfosFwdPtr_;      // Refactorized embedding
+    TagInfoFwdPtrCollection tagInfosFwdPtr_;
 
     // ---- track related members ----
 
@@ -659,14 +658,6 @@ namespace pat {
       for (size_t i = 0, n = tagInfosFwdPtr_.size(); i < n; ++i) {
         TagInfoFwdPtrCollection::value_type const& val = tagInfosFwdPtr_[i];
         reco::BaseTagInfo const* baseTagInfo = val.get();
-        if (typeid(*baseTagInfo) == typeid(T)) {
-          return static_cast<const T*>(baseTagInfo);
-        }
-      }
-      // Then check compatibility version
-      for (size_t i = 0, n = tagInfos_.size(); i < n; ++i) {
-        edm::OwnVector<reco::BaseTagInfo>::value_type const& val = tagInfos_[i];
-        reco::BaseTagInfo const* baseTagInfo = &val;
         if (typeid(*baseTagInfo) == typeid(T)) {
           return static_cast<const T*>(baseTagInfo);
         }

--- a/DataFormats/PatCandidates/src/Jet.cc
+++ b/DataFormats/PatCandidates/src/Jet.cc
@@ -366,8 +366,6 @@ const reco::BaseTagInfo* Jet::tagInfo(const std::string& label) const {
     if (tagInfoLabels_[i] == label) {
       if (!tagInfosFwdPtr_.empty())
         return tagInfosFwdPtr_[i].get();
-      else if (!tagInfos_.empty())
-        return &tagInfos_[i];
       return nullptr;
     }
   }

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -251,8 +251,9 @@
              newObj->setPflowIsolationVariables(pfIsoVar);]]>
   </ioread>
 
-  <class name="pat::Jet"  ClassVersion="17">
-   <version ClassVersion="17" checksum="739868501"/>
+  <class name="pat::Jet"  ClassVersion="18">
+    <version ClassVersion="18" checksum="1519176793"/>
+    <version ClassVersion="17" checksum="739868501"/>
    <field name="daughtersTemp_" transient="true"/>
    <version ClassVersion="16" checksum="4069285947"/>
    <version ClassVersion="15" checksum="727883729"/>

--- a/PhysicsTools/PatAlgos/plugins/PATJetSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATJetSlimmer.cc
@@ -106,7 +106,6 @@ void pat::PATJetSlimmer::produce(edm::Event& iEvent, const edm::EventSetup& iSet
 
     if (dropTagInfos_(*it)) {
       jet.tagInfoLabels_.clear();
-      jet.tagInfos_.clear();
       jet.tagInfosFwdPtr_.clear();
     }
     if (dropJetVars_(*it)) {


### PR DESCRIPTION
#### PR description:

The interface to add an embedded object was removed in 2010 and the member data was only kept to read very old files.

#### PR validation:

Code compiles.