### PR TITLE
RefToBase to Ptr conversion for GsfElectron

### DIFF
--- a/DataFormats/EgammaCandidates/interface/GsfElectron.h
+++ b/DataFormats/EgammaCandidates/interface/GsfElectron.h
@@ -626,7 +626,7 @@ namespace reco {
   public:
     struct ConversionRejection {
       int flags;             // -max:not-computed, other: as computed by Puneeth conversion code
-      TrackBaseRef partner;  // conversion partner
+      TrackPtr partner;  // conversion partner
       float dist;            // distance to the conversion partner
       float dcot;            // difference of cot(angle) with the conversion partner track
       float radius;          // signed conversion radius
@@ -641,7 +641,7 @@ namespace reco {
 
     // accessors
     int convFlags() const { return conversionRejection_.flags; }
-    TrackBaseRef convPartner() const { return conversionRejection_.partner; }
+    TrackPtr convPartner() const { return conversionRejection_.partner; }
     float convDist() const { return conversionRejection_.dist; }
     float convDcot() const { return conversionRejection_.dcot; }
     float convRadius() const { return conversionRejection_.radius; }

--- a/DataFormats/EgammaCandidates/src/GsfElectron.cc
+++ b/DataFormats/EgammaCandidates/src/GsfElectron.cc
@@ -2,6 +2,7 @@
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
 #include "DataFormats/EgammaReco/interface/BasicCluster.h"
 #include "DataFormats/EgammaReco/interface/BasicClusterFwd.h"
+#include "DataFormats/Common/interface/RefToBaseToPtr.h"
 
 using namespace reco;
 
@@ -136,7 +137,7 @@ GsfElectron::GsfElectron(const GsfElectron& electron,
       pixelMatchVariables_(electron.pixelMatchVariables_) {
   trackClusterMatching_.electronCluster = electronCluster;
   //closestCtfTrack_.ctfTrack = closestCtfTrack ;
-  conversionRejection_.partner = conversionPartner;
+  conversionRejection_.partner = edm::refToBaseToPtr(conversionPartner);
   //assert(closestCtfTrack==core->ctfTrack()) ;
   //assert(electron.core()->ctfGsfOverlap()==core->ctfGsfOverlap()) ;
   // TO BE DONE

--- a/DataFormats/EgammaCandidates/src/classes.h
+++ b/DataFormats/EgammaCandidates/src/classes.h
@@ -35,6 +35,7 @@
 #include "DataFormats/Common/interface/AssociationMap.h"
 #include "DataFormats/Common/interface/Ptr.h"
 #include "DataFormats/Common/interface/PtrVector.h"
+#include "DataFormats/Common/interface/RefToBaseToPtr_ioread.h"
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "Rtypes.h"
 #include "Math/Cartesian3D.h"

--- a/DataFormats/EgammaCandidates/src/classes_def.xml
+++ b/DataFormats/EgammaCandidates/src/classes_def.xml
@@ -176,7 +176,11 @@
    <version ClassVersion="11" checksum="1799511018"/>
    <version ClassVersion="10" checksum="4260674990"/>
   </class>
-  <class name="reco::GsfElectron::ConversionRejection" ClassVersion="11">
+  <class name="reco::GsfElectron::ConversionRejection" ClassVersion="12">
+   <version ClassVersion="12" checksum="2742251964"/>
+  <ioread sourceClass="reco::GsfElectron::ConversionRejection" version="[1-11]" source="reco::TrackBaseRef partner" targetClass="reco::GsfElectron::ConversionRejection" target="partner">
+    <![CDATA[ partner = edm::refToBaseToPtr_ioread(onfile.partner); ]]>
+   </ioread>
    <version ClassVersion="11" checksum="2813508647"/>
    <version ClassVersion="10" checksum="190549577"/>
   </class>

--- a/DataFormats/TrackReco/interface/TrackFwd.h
+++ b/DataFormats/TrackReco/interface/TrackFwd.h
@@ -7,6 +7,7 @@
 #include "DataFormats/Common/interface/RefVector.h"
 #include "DataFormats/Common/interface/RefToBase.h"
 #include "DataFormats/Common/interface/RefToBaseVector.h"
+#include "DataFormats/Common/interface/Ptr.h"
 #include "DataFormats/Common/interface/Association.h"
 
 namespace reco {
@@ -33,6 +34,9 @@ namespace reco {
 
   /// persistent reference to a Track, using views
   typedef edm::RefToBase<reco::Track> TrackBaseRef;
+
+  /// persistent reference to a Track, RNTuple-safe
+  typedef edm::Ptr<reco::Track> TrackPtr;
 
   /// vector of persistent references to a Track, using views
   typedef edm::RefToBaseVector<reco::Track> TrackBaseRefVector;

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -1042,10 +1042,9 @@ void GsfElectronAlgo::createElectron(reco::GsfElectronCollection& electrons,
     conversionVars.vtxFitProb = ConversionTools::getVtxFitProb(matchedConv);
   }
   if (conversionInfo.conversionPartnerCtfTkIdx) {
-    conversionVars.partner = TrackBaseRef(reco::TrackRef(ctfTracks, conversionInfo.conversionPartnerCtfTkIdx.value()));
+    conversionVars.partner = reco::TrackPtr(ctfTracks, conversionInfo.conversionPartnerCtfTkIdx.value());
   } else if (conversionInfo.conversionPartnerGsfTkIdx) {
-    conversionVars.partner =
-        TrackBaseRef(reco::GsfTrackRef(eventData.originalGsfTracks, conversionInfo.conversionPartnerGsfTkIdx.value()));
+    conversionVars.partner = reco::TrackPtr(eventData.originalGsfTracks, conversionInfo.conversionPartnerGsfTkIdx.value());
   }
 
   //====================================================


### PR DESCRIPTION
#### PR description:

Changes the `reco::GsfElectron::ConversionRejection::partner` data object to a `edm::Ptr` type.
The `reco::GsfElectron::convPartner()` accessor API has a new type, though no downstream code appears to use it.

#### PR validation:

Code compiles.
In FWLite, not able to access the pointer...