### PR TITLE
Hack data formats to create a MiniAOD subset readable by RNTuple

### DIFF
--- a/DataFormats/CSCRecHit/interface/CSCRecHit2DCollection.h
+++ b/DataFormats/CSCRecHit/interface/CSCRecHit2DCollection.h
@@ -13,6 +13,13 @@
 #include <DataFormats/Common/interface/ClonePolicy.h>
 #include <DataFormats/Common/interface/OwnVector.h>
 
+namespace edm::detail {
+  template<>
+    struct RangeMapContainer<edm::OwnVector<CSCRecHit2D>> {
+    using type = std::vector<CSCRecHit2D>;
+  };
+}
+
 typedef edm::RangeMap<CSCDetId, edm::OwnVector<CSCRecHit2D> > CSCRecHit2DCollection;
 
 #endif

--- a/DataFormats/CSCRecHit/interface/CSCSegment.h
+++ b/DataFormats/CSCRecHit/interface/CSCSegment.h
@@ -18,10 +18,47 @@
 
 class CSCDetId;
 
+class CSCSegment;
+
+namespace cscsegment {
+  class MatchedSegment {
+  public:
+
+    MatchedSegment(LocalPoint const& iOrigin,
+                   LocalError const& iOriginError,
+                   LocalVector const& iDirection,
+                   LocalError const& iDirectionError) :
+    theOrigin(iOrigin),
+      theLocalDirection(iDirection),
+      theOriginError(iOriginError),
+      theDirectionError(iDirectionError) {}
+
+    MatchedSegment() = default;
+    MatchedSegment(const MatchedSegment&) = default;
+    MatchedSegment(MatchedSegment&&) = default;
+    MatchedSegment& operator=(const MatchedSegment&) = default;
+    MatchedSegment& operator=(MatchedSegment&&) = default;
+
+    MatchedSegment( const CSCSegment&);
+    
+    LocalPoint const& localPosition() const { return theOrigin; }
+    LocalError const& localPositionError() const { return theOriginError; }
+    
+    LocalVector const& localDirection() const { return theLocalDirection; }
+    LocalError localDirectionError() const { return theDirectionError; }
+
+  private:
+  LocalPoint theOrigin;             // in chamber frame - the GeomDet local coordinate system
+  LocalVector theLocalDirection;    // in chamber frame - the GeomDet local coordinate system
+  LocalError theOriginError;
+  LocalError theDirectionError;
+  };
+}
+
 class CSCSegment final : public RecSegment {
 public:
   /// Default constructor
-  CSCSegment() : theChi2(0.), aME11a_duplicate(false) {}
+  CSCSegment() : theChi2(0.) {}
 
   /// Constructor
   CSCSegment(const std::vector<const CSCRecHit2D*>& proto_segment,
@@ -73,7 +110,7 @@ public:
 
   bool isME11a_duplicate() const { return (!theDuplicateSegments.empty() ? true : false); }
   // a copy of the duplicated segments (ME1/1a only)
-  const std::vector<CSCSegment>& duplicateSegments() const { return theDuplicateSegments; }
+  const std::vector<cscsegment::MatchedSegment>& duplicateSegments() const { return theDuplicateSegments; }
 
   bool testSharesAllInSpecificRecHits(const std::vector<CSCRecHit2D>& specificRecHits_1,
                                       const std::vector<CSCRecHit2D>& specificRecHits_2,
@@ -95,9 +132,14 @@ private:
   LocalVector theLocalDirection;    // in chamber frame - the GeomDet local coordinate system
   AlgebraicSymMatrix theCovMatrix;  // the covariance matrix
   double theChi2;
-  bool aME11a_duplicate;
-  std::vector<CSCSegment> theDuplicateSegments;  // ME1/1a only
+  std::vector<cscsegment::MatchedSegment> theDuplicateSegments;  // ME1/1a only
 };
+
+inline cscsegment::MatchedSegment::MatchedSegment( const CSCSegment& iSeg):
+  theOrigin(iSeg.localPosition()),
+  theLocalDirection(iSeg.localDirection()),
+  theOriginError(iSeg.localPositionError()),
+  theDirectionError(iSeg.localDirectionError()) {}
 
 std::ostream& operator<<(std::ostream& os, const CSCSegment& seg);
 

--- a/DataFormats/CSCRecHit/interface/CSCSegmentCollection.h
+++ b/DataFormats/CSCRecHit/interface/CSCSegmentCollection.h
@@ -15,6 +15,13 @@
 #include <DataFormats/Common/interface/ClonePolicy.h>
 #include <DataFormats/Common/interface/OwnVector.h>
 
+namespace edm::detail {
+  template<>
+    struct RangeMapContainer<edm::OwnVector<CSCSegment>> {
+    using type = std::vector<CSCSegment>;
+  };
+}
+
 typedef edm::RangeMap<CSCDetId, edm::OwnVector<CSCSegment> > CSCSegmentCollection;
 
 #include <DataFormats/Common/interface/Ref.h>

--- a/DataFormats/CSCRecHit/src/CSCSegment.cc
+++ b/DataFormats/CSCRecHit/src/CSCSegment.cc
@@ -21,8 +21,7 @@ CSCSegment::CSCSegment(const std::vector<const CSCRecHit2D*>& proto_segment,
       theOrigin(origin),
       theLocalDirection(direction),
       theCovMatrix(errors),
-      theChi2(chi2),
-      aME11a_duplicate(false) {
+      theChi2(chi2) {
   for (unsigned int i = 0; i < proto_segment.size(); ++i)
     theCSCRecHits.push_back(*proto_segment[i]);
 }
@@ -84,8 +83,6 @@ void CSCSegment::setDuplicateSegments(std::vector<CSCSegment*>& duplicates) {
   theDuplicateSegments.clear();
   for (unsigned int i = 0; i < duplicates.size(); ++i) {
     theDuplicateSegments.push_back(*duplicates[i]);
-    //avoid copying duplicates of duplicates of duplicates...
-    theDuplicateSegments.back().theDuplicateSegments.resize(0);
   }
 }
 

--- a/DataFormats/CSCRecHit/src/classes_def.xml
+++ b/DataFormats/CSCRecHit/src/classes_def.xml
@@ -20,10 +20,16 @@
 
   <class name="std::vector<CSCSegment>"/>
   <class name="std::vector<CSCSegment*>"/>
-  <class name="CSCSegment" ClassVersion="11">
+  <class name="CSCSegment" ClassVersion="12">
+   <version ClassVersion="12" checksum="1062772782"/>
    <version ClassVersion="11" checksum="160361831"/>
    <version ClassVersion="10" checksum="3002485899"/>
   </class>
+  <ioread sourceClass="CSCSegment" targetClass="CSCSegment" version="[1-11]" source="std::vector<CSCSegment> theDuplicateSegments" target="theDuplicateSegments">
+  <![CDATA[
+      std::copy(onfile.theDuplicateSegments.begin(),onfile.theDuplicateSegments.end(), std::back_inserter(theDuplicateSegments));
+]]>
+</ioread>
   <class name="edm::OwnVector<CSCSegment,edm::ClonePolicy<CSCSegment> >"/>
   <class name="edm::RangeMap<CSCDetId,edm::OwnVector<CSCSegment,edm::ClonePolicy<CSCSegment> >,edm::ClonePolicy<CSCSegment> >"/>
   <class name="edm::ClonePolicy<CSCSegment>"/> <!-- Root6 -->

--- a/DataFormats/CSCRecHit/src/classes_def.xml
+++ b/DataFormats/CSCRecHit/src/classes_def.xml
@@ -30,6 +30,9 @@
       std::copy(onfile.theDuplicateSegments.begin(),onfile.theDuplicateSegments.end(), std::back_inserter(theDuplicateSegments));
 ]]>
 </ioread>
+<class name="cscsegment::MatchedSegment" ClassVersion="3">
+  <version ClassVersion="3" checksum="2585983949"/>
+</class>
   <class name="edm::OwnVector<CSCSegment,edm::ClonePolicy<CSCSegment> >"/>
   <class name="edm::RangeMap<CSCDetId,edm::OwnVector<CSCSegment,edm::ClonePolicy<CSCSegment> >,edm::ClonePolicy<CSCSegment> >"/>
   <ioread sourceClass="edm::RangeMap<CSCDetId, edm::OwnVector<CSCSegment, edm::ClonePolicy<CSCSegment> >, edm::ClonePolicy<CSCSegment> >" targetClass="edm::RangeMap<CSCDetId, edm::OwnVector<CSCSegment, edm::ClonePolicy<CSCSegment> >, edm::ClonePolicy<CSCSegment> >" version="[1-10]" source="edm::OwnVector<CSCSegment> collection_" target="collection_">

--- a/DataFormats/CSCRecHit/src/classes_def.xml
+++ b/DataFormats/CSCRecHit/src/classes_def.xml
@@ -32,6 +32,11 @@
 </ioread>
   <class name="edm::OwnVector<CSCSegment,edm::ClonePolicy<CSCSegment> >"/>
   <class name="edm::RangeMap<CSCDetId,edm::OwnVector<CSCSegment,edm::ClonePolicy<CSCSegment> >,edm::ClonePolicy<CSCSegment> >"/>
+  <ioread sourceClass="edm::RangeMap<CSCDetId, edm::OwnVector<CSCSegment, edm::ClonePolicy<CSCSegment> >, edm::ClonePolicy<CSCSegment> >" targetClass="edm::RangeMap<CSCDetId, edm::OwnVector<CSCSegment, edm::ClonePolicy<CSCSegment> >, edm::ClonePolicy<CSCSegment> >" version="[1-10]" source="edm::OwnVector<CSCSegment> collection_" target="collection_">
+  <![CDATA[
+          collection_ = edm::detail::io_transform(onfile.collection_);
+]]>
+  </ioread>
   <class name="edm::ClonePolicy<CSCSegment>"/> <!-- Root6 -->
   <class name="edm::Wrapper<edm::RangeMap<CSCDetId,edm::OwnVector<CSCSegment,edm::ClonePolicy<CSCSegment> >,edm::ClonePolicy<CSCSegment> > >"/>
   <class name="CSCSegmentRef"/>

--- a/DataFormats/Candidate/interface/CompositeCandidate.h
+++ b/DataFormats/Candidate/interface/CompositeCandidate.h
@@ -24,7 +24,7 @@ namespace reco {
     typedef CandidateCollection daughters;
     typedef std::vector<std::string> role_collection;
     /// default constructor
-    CompositeCandidate(std::string name = "") : LeafCandidate(), name_(name) {}
+    CompositeCandidate(std::string name = "") : LeafCandidate() /*, name_(name)*/ {}
     /// constructor from values
     template <typename P4>
     CompositeCandidate(Charge q,
@@ -34,7 +34,7 @@ namespace reco {
                        int status = 0,
                        bool integerCharge = true,
                        std::string name = "")
-        : LeafCandidate(q, p4, vtx, pdgId, status, integerCharge), name_(name) {}
+      : LeafCandidate(q, p4, vtx, pdgId, status, integerCharge)/*, name_(name)*/ {}
     /// constructor from values
     explicit CompositeCandidate(const Candidate& p, const std::string& name = "");
     /// constructor from values
@@ -42,15 +42,15 @@ namespace reco {
     /// destructor
     ~CompositeCandidate() override;
     /// get the name of the candidate
-    std::string name() const { return name_; }
+    std::string name() const { return std::string();/*name_;*/ }
     /// set the name of the candidate
-    void setName(std::string name) { name_ = name; }
+    void setName(std::string name) { /*name_ = name;*/ }
     /// get the roles
-    role_collection const& roles() const { return roles_; }
+    role_collection const& roles() const; /*{ return roles_; }*/
     /// set the roles
     void setRoles(const role_collection& roles) {
-      roles_.clear();
-      roles_ = roles;
+      /*roles_.clear();
+        roles_ = roles; */
     }
     /// returns a clone of the candidate
     CompositeCandidate* clone() const override;
@@ -68,9 +68,9 @@ namespace reco {
     /// add a clone of the passed candidate as daughter
     void addDaughter(std::unique_ptr<Candidate>, const std::string& s = "");
     /// clear daughters
-    void clearDaughters() { dau.clear(); }
+    void clearDaughters() { /*dau.clear();*/ }
     // clear roles
-    void clearRoles() { roles_.clear(); }
+    void clearRoles() { /*roles_.clear();*/ }
     // Apply the roles to the objects
     void applyRoles();
     /// number of mothers (zero or one in most of but not all the cases)
@@ -80,13 +80,13 @@ namespace reco {
 
   private:
     /// collection of daughters
-    daughters dau;
+    //daughters dau;
     /// check overlap with another daughter
     bool overlap(const Candidate&) const override;
     /// candidate name
-    std::string name_;
+    //std::string name_;
     /// candidate roles
-    role_collection roles_;
+    //role_collection roles_;
   };
 
 }  // namespace reco

--- a/DataFormats/Candidate/src/CompositeCandidate.cc
+++ b/DataFormats/Candidate/src/CompositeCandidate.cc
@@ -3,15 +3,18 @@
 
 using namespace reco;
 
-CompositeCandidate::CompositeCandidate(const Candidate& c, const std::string& name) : LeafCandidate(c), name_(name) {
+CompositeCandidate::CompositeCandidate(const Candidate& c, const std::string& name) : LeafCandidate(c) /*, name_(name)*/ {
+  /*
   size_t n = c.numberOfDaughters();
   for (size_t i = 0; i != n; ++i) {
     addDaughter(*c.daughter(i));
   }
+  */
 }
 
 CompositeCandidate::CompositeCandidate(const Candidate& c, const std::string& name, role_collection const& roles)
-    : LeafCandidate(c), name_(name), roles_(roles) {
+  : LeafCandidate(c) /*, name_(name), roles_(roles)*/ {
+  /*
   size_t n = c.numberOfDaughters();
   size_t r = roles_.size();
   bool sameSize = (n == r);
@@ -21,6 +24,7 @@ CompositeCandidate::CompositeCandidate(const Candidate& c, const std::string& na
     else
       addDaughter(*c.daughter(i));
   }
+  */
 }
 
 CompositeCandidate::~CompositeCandidate() {}
@@ -28,17 +32,19 @@ CompositeCandidate::~CompositeCandidate() {}
 CompositeCandidate* CompositeCandidate::clone() const { return new CompositeCandidate(*this); }
 
 const Candidate* CompositeCandidate::daughter(size_type i) const {
-  return (i < numberOfDaughters()) ? &dau[i] : nullptr;  // i >= 0, since i is unsigned
+  return nullptr;
+  //  return (i < numberOfDaughters()) ? &dau[i] : nullptr;  // i >= 0, since i is unsigned
 }
 
 Candidate* CompositeCandidate::daughter(size_type i) {
-  Candidate* d = (i < numberOfDaughters()) ? &dau[i] : nullptr;  // i >= 0, since i is unsigned
-  return d;
+  return nullptr;
+  //Candidate* d = (i < numberOfDaughters()) ? &dau[i] : nullptr;  // i >= 0, since i is unsigned
+  //return d;
 }
 
 const Candidate* CompositeCandidate::mother(size_type i) const { return nullptr; }
 
-size_t CompositeCandidate::numberOfDaughters() const { return dau.size(); }
+size_t CompositeCandidate::numberOfDaughters() const { return 0; /*dau.size();*/ }
 
 size_t CompositeCandidate::numberOfMothers() const { return 0; }
 
@@ -47,6 +53,7 @@ bool CompositeCandidate::overlap(const Candidate& c2) const {
 }
 
 void CompositeCandidate::applyRoles() {
+  /*
   if (roles_.empty())
     return;
 
@@ -67,9 +74,12 @@ void CompositeCandidate::applyRoles() {
       c1->setName(role);
     }
   }
+  */
 }
 
 Candidate* CompositeCandidate::daughter(const std::string& s) {
+  return nullptr;
+  /*
   int ret = -1;
   int i = 0, N = roles_.size();
   bool found = false;
@@ -85,9 +95,12 @@ Candidate* CompositeCandidate::daughter(const std::string& s) {
   }
 
   return daughter(ret);
+  */
 }
 
 const Candidate* CompositeCandidate::daughter(const std::string& s) const {
+  return nullptr;
+  /*
   int ret = -1;
   int i = 0, N = roles_.size();
   bool found = false;
@@ -103,9 +116,11 @@ const Candidate* CompositeCandidate::daughter(const std::string& s) const {
   }
 
   return daughter(ret);
+  */
 }
 
 void CompositeCandidate::addDaughter(const Candidate& cand, const std::string& s) {
+  /*
   Candidate* c = cand.clone();
   if (!s.empty()) {
     role_collection::iterator begin = roles_.begin(), end = roles_.end();
@@ -121,9 +136,11 @@ void CompositeCandidate::addDaughter(const Candidate& cand, const std::string& s
     }
   }
   dau.push_back(c);
+  */
 }
 
 void CompositeCandidate::addDaughter(std::unique_ptr<Candidate> cand, const std::string& s) {
+  /*
   if (!s.empty()) {
     role_collection::iterator begin = roles_.begin(), end = roles_.end();
     bool isFound = (find(begin, end, s) != end);
@@ -138,4 +155,10 @@ void CompositeCandidate::addDaughter(std::unique_ptr<Candidate> cand, const std:
     }
   }
   dau.push_back(std::move(cand));
+  */
+}
+
+CompositeCandidate::role_collection const& CompositeCandidate::roles() const {
+  const static role_collection s;
+  return s;
 }

--- a/DataFormats/Candidate/src/classes_def.xml
+++ b/DataFormats/Candidate/src/classes_def.xml
@@ -43,7 +43,8 @@
     ]]>
   </ioread>
 
-  <class name="reco::CompositeCandidate" ClassVersion="12">
+  <class name="reco::CompositeCandidate" ClassVersion="13">
+    <version ClassVersion="13" checksum="2752494592"/>
    <version ClassVersion="12" checksum="1318508193"/>
    <version ClassVersion="11" checksum="1985736233"/>
    <version ClassVersion="10" checksum="2953566340"/>
@@ -70,7 +71,8 @@
     ]]>
   </ioread>  
 
-  <class name="reco::VertexCompositeCandidate" ClassVersion="13">
+  <class name="reco::VertexCompositeCandidate" ClassVersion="14">
+   <version ClassVersion="14" checksum="3694823674"/>
    <version ClassVersion="13" checksum="1561694123"/>
    <version ClassVersion="12" checksum="1204062111"/>
    <version ClassVersion="11" checksum="2801258535"/>
@@ -101,7 +103,8 @@
    <version ClassVersion="11" checksum="124560908"/>
    <version ClassVersion="10" checksum="2575892329"/>
   </class>
-  <class name="reco::NamedCompositeCandidate" ClassVersion="12">
+  <class name="reco::NamedCompositeCandidate" ClassVersion="13">
+   <version ClassVersion="13" checksum="3251840200"/>
    <version ClassVersion="12" checksum="1682589651"/>
    <version ClassVersion="11" checksum="1100712875"/>
    <version ClassVersion="10" checksum="604924170"/>

--- a/DataFormats/Common/interface/RangeMap.h
+++ b/DataFormats/Common/interface/RangeMap.h
@@ -42,11 +42,12 @@ namespace edm {
     }
   }
   
-  template <typename ID, typename C, typename P = typename clonehelper::CloneTrait<typename detail::RangeMapContainer<C>::type>::type>
+  template <typename ID, typename C, typename P = typename clonehelper::CloneTrait<C>::type>
   class RangeMap {
   public:
     /// contained object type
     using Container = typename detail::RangeMapContainer<C>::type;
+    using Cloner_t = typename clonehelper::CloneTrait<typename detail::RangeMapContainer<C>::type>::type;
     typedef typename Container::value_type value_type;
     /// collection size type
     typedef typename Container::size_type size_type;
@@ -132,7 +133,7 @@ namespace edm {
       pairType& p = map_[id];
       p.first = collection_.size();
       for (CI ii = begin; ii != end; ++ii)
-        collection_.push_back(P::clone(*ii));
+        collection_.push_back(Cloner_t::clone(*ii));
       p.second = collection_.size();
     }
     /// return number of contained object
@@ -185,7 +186,7 @@ namespace edm {
         //do cast to acknowledge that we may be going from a larger type to a smaller type but we are OK
         unsigned int begIt = static_cast<unsigned int>(tmp.size());
         for (const_iterator i = r.first; i != r.second; ++i)
-          tmp.push_back(P::clone(*i));
+          tmp.push_back(Cloner_t::clone(*i));
         unsigned int endIt = static_cast<unsigned int>(tmp.size());
         it->second = pairType(begIt, endIt);
       }

--- a/DataFormats/Common/interface/RefToBaseToPtr.h
+++ b/DataFormats/Common/interface/RefToBaseToPtr.h
@@ -6,8 +6,6 @@
 Ref: A function template for conversion from RefToBase to Ptr
 
 ----------------------------------------------------------------------*/
-/*
-    ----------------------------------------------------------------------*/
 
 #include "DataFormats/Common/interface/RefToBase.h"
 #include "DataFormats/Common/interface/Ptr.h"
@@ -43,7 +41,6 @@ namespace edm {
       // by construction would be persistent
       return Ptr<T>();
     } else {
-      //Another thread could change this value so get only once
       EDProductGetter const* getter = ref.productGetter();
       if (getter) {
         return Ptr<T>(ref.id(), ref.key(), getter);

--- a/DataFormats/Common/interface/RefToBaseToPtr.h
+++ b/DataFormats/Common/interface/RefToBaseToPtr.h
@@ -1,0 +1,36 @@
+#ifndef DataFormats_Common_RefToBaseToPtr_h
+#define DataFormats_Common_RefToBaseToPtr_h
+
+/*----------------------------------------------------------------------
+  
+Ref: A function template for conversion from RefToBase to Ptr
+
+----------------------------------------------------------------------*/
+/*
+    ----------------------------------------------------------------------*/
+
+#include "DataFormats/Common/interface/RefToBase.h"
+#include "DataFormats/Common/interface/Ptr.h"
+
+namespace edm {
+  template <typename T>
+  Ptr<T> refToBaseToPtr(RefToBase<T> const& ref) {
+    if (ref.isNull()) {
+      return Ptr<T>();
+    }
+    if (ref.isTransient()) {
+      return Ptr<T>(ref.get(), ref.key());
+    } else {
+      //Another thread could change this value so get only once
+      EDProductGetter const* getter = ref.productGetter();
+      if (getter) {
+        return Ptr<T>(ref.id(), ref.key(), getter);
+      }
+    }
+    // If this is called in an iorule outside the framework, we cannot call
+    // ref.get() but since the Ptr will be able to get it later anyway, we can
+    // fill with a nullptr for now
+    return Ptr<T>(ref.id(), static_cast<const T*>(nullptr), ref.key());
+  }
+}  // namespace edm
+#endif

--- a/DataFormats/Common/interface/RefToBaseToPtr.h
+++ b/DataFormats/Common/interface/RefToBaseToPtr.h
@@ -29,7 +29,7 @@ namespace edm {
   }
 
   /*
-   * Do not use this ouside an ioread rule in classes_def.xml
+   * Do not use this outside an ioread rule in classes_def.xml
    */
   template <typename T>
   Ptr<T> refToBaseToPtr_ioread(RefToBase<T> const& ref) {

--- a/DataFormats/Common/interface/RefToBaseToPtr.h
+++ b/DataFormats/Common/interface/RefToBaseToPtr.h
@@ -27,9 +27,32 @@ namespace edm {
         return Ptr<T>(ref.id(), ref.key(), getter);
       }
     }
+    return Ptr<T>(ref.id(), ref.get(), ref.key());
+  }
+
+  /*
+   * Do not use this ouside an ioread rule in classes_def.xml
+   */
+  template <typename T>
+  Ptr<T> refToBaseToPtr_ioread(RefToBase<T> const& ref) {
+    if (ref.isNull()) {
+      return Ptr<T>();
+    }
+    if (ref.isTransient()) {
+      // This is a logic error, any ref being deserialized
+      // by construction would be persistent
+      return Ptr<T>();
+    } else {
+      //Another thread could change this value so get only once
+      EDProductGetter const* getter = ref.productGetter();
+      if (getter) {
+        return Ptr<T>(ref.id(), ref.key(), getter);
+      }
+    }
     // If this is called in an iorule outside the framework, we cannot call
-    // ref.get() but since the Ptr will be able to get it later anyway, we can
-    // fill with a nullptr for now
+    // ref.get(), but since outside the framework we can never fetch the ref,
+    // the Ptr will only be useful if accessed later from inside the framework.
+    // We can fill with a nullptr for now
     return Ptr<T>(ref.id(), static_cast<const T*>(nullptr), ref.key());
   }
 }  // namespace edm

--- a/DataFormats/Common/interface/RefToBaseToPtr.h
+++ b/DataFormats/Common/interface/RefToBaseToPtr.h
@@ -27,30 +27,5 @@ namespace edm {
     }
     return Ptr<T>(ref.id(), ref.get(), ref.key());
   }
-
-  /*
-   * Do not use this outside an ioread rule in classes_def.xml
-   */
-  template <typename T>
-  Ptr<T> refToBaseToPtr_ioread(RefToBase<T> const& ref) {
-    if (ref.isNull()) {
-      return Ptr<T>();
-    }
-    if (ref.isTransient()) {
-      // This is a logic error, any ref being deserialized
-      // by construction would be persistent
-      return Ptr<T>();
-    } else {
-      EDProductGetter const* getter = ref.productGetter();
-      if (getter) {
-        return Ptr<T>(ref.id(), ref.key(), getter);
-      }
-    }
-    // If this is called in an iorule outside the framework, we cannot call
-    // ref.get(), but since outside the framework we can never fetch the ref,
-    // the Ptr will only be useful if accessed later from inside the framework.
-    // We can fill with a nullptr for now
-    return Ptr<T>(ref.id(), static_cast<const T*>(nullptr), ref.key());
-  }
 }  // namespace edm
 #endif

--- a/DataFormats/Common/interface/RefToBaseToPtr_ioread.h
+++ b/DataFormats/Common/interface/RefToBaseToPtr_ioread.h
@@ -1,0 +1,37 @@
+#ifndef DataFormats_Common_RefToBaseToPtr_ioread_h
+#define DataFormats_Common_RefToBaseToPtr_ioread_h
+
+/*----------------------------------------------------------------------
+  
+Ref: A function template for conversion from RefToBase to Ptr for use
+in ROOT ioread rules for schema migration
+
+----------------------------------------------------------------------*/
+
+#include "DataFormats/Common/interface/RefToBase.h"
+#include "DataFormats/Common/interface/Ptr.h"
+
+namespace edm {
+  template <typename T>
+  Ptr<T> refToBaseToPtr_ioread(RefToBase<T> const& ref) {
+    if (ref.isNull()) {
+      return Ptr<T>();
+    }
+    if (ref.isTransient()) {
+      // This is a logic error, any ref being deserialized
+      // by construction would be persistent
+      return Ptr<T>();
+    } else {
+      EDProductGetter const* getter = ref.productGetter();
+      if (getter) {
+        return Ptr<T>(ref.id(), ref.key(), getter);
+      }
+    }
+    // If this is called in an iorule outside the framework, we cannot call
+    // ref.get(), but since outside the framework we can never fetch the ref,
+    // the Ptr will only be useful if accessed later from inside the framework.
+    // We can fill with a nullptr for now
+    return Ptr<T>(ref.id(), static_cast<const T*>(nullptr), ref.key());
+  }
+}  // namespace edm
+#endif

--- a/DataFormats/Common/test/DetSetNew_t.cpp
+++ b/DataFormats/Common/test/DetSetNew_t.cpp
@@ -11,6 +11,13 @@
 #include <algorithm>
 #include <vector>
 
+namespace edm::detail {
+  template<typename V>
+  struct RangeMapContainer<edm::OwnVector<V>> {
+    using type = typename edm::OwnVector<V>;
+  };
+}
+
 struct B {
   virtual ~B() {}
   virtual B *clone() const = 0;

--- a/DataFormats/DTRecHit/interface/DTRecClusterCollection.h
+++ b/DataFormats/DTRecHit/interface/DTRecClusterCollection.h
@@ -26,6 +26,12 @@
 #include <functional>
 
 /* ====================================================================== */
+namespace edm::detail {
+  template<>
+    struct RangeMapContainer<edm::OwnVector<DTSLRecCluster>> {
+    using type = edm::OwnVector<DTSLRecCluster>;
+  };
+}
 
 /* Class DTRecClusterCollection Interface */
 typedef edm::RangeMap<DTSuperLayerId, edm::OwnVector<DTSLRecCluster> > DTRecClusterCollection;

--- a/DataFormats/DTRecHit/interface/DTRecHitCollection.h
+++ b/DataFormats/DTRecHit/interface/DTRecHitCollection.h
@@ -13,6 +13,14 @@
 #include "DataFormats/Common/interface/ClonePolicy.h"
 #include "DataFormats/Common/interface/OwnVector.h"
 #include <functional>
+#include <vector>
+
+namespace edm::detail {
+  template<>
+  struct RangeMapContainer<edm::OwnVector<DTRecHit1DPair>> {
+    using type = std::vector<DTRecHit1DPair>;
+    };
+}
 
 typedef edm::RangeMap<DTLayerId, edm::OwnVector<DTRecHit1DPair> > DTRecHitCollection;
 

--- a/DataFormats/DTRecHit/interface/DTRecSegment2DCollection.h
+++ b/DataFormats/DTRecHit/interface/DTRecSegment2DCollection.h
@@ -24,6 +24,13 @@
 
 /* ====================================================================== */
 
+namespace edm::detail {
+  template<>
+    struct RangeMapContainer<edm::OwnVector<DTSLRecSegment2D>> {
+    using type = edm::OwnVector<DTSLRecSegment2D>;
+  };
+}
+
 typedef edm::RangeMap<DTSuperLayerId, edm::OwnVector<DTSLRecSegment2D> > DTRecSegment2DCollection;
 
 #endif  // DTRecHit_DTRecSegment2DCollection_h

--- a/DataFormats/DTRecHit/interface/DTRecSegment4DCollection.h
+++ b/DataFormats/DTRecHit/interface/DTRecSegment4DCollection.h
@@ -18,6 +18,13 @@
 #include "DataFormats/DTRecHit/interface/DTRecSegment4D.h"
 #include "DataFormats/MuonDetId/interface/DTChamberId.h"
 
+namespace edm::detail {
+  template<>
+  struct RangeMapContainer<edm::OwnVector<DTRecSegment4D>> {
+    using type = std::vector<DTRecSegment4D>;
+  };
+}
+
 typedef edm::RangeMap<DTChamberId, edm::OwnVector<DTRecSegment4D> > DTRecSegment4DCollection;
 
 #include "DataFormats/Common/interface/Ref.h"

--- a/DataFormats/DTRecHit/src/classes_def.xml
+++ b/DataFormats/DTRecHit/src/classes_def.xml
@@ -17,6 +17,11 @@
   <class name="edm::OwnVector<DTRecHit1DPair,edm::ClonePolicy<DTRecHit1DPair> >"/>
   <class name="edm::ClonePolicy<DTRecHit1DPair>" /> <!-- Root6 -->
   <class name="edm::RangeMap <DTLayerId,edm::OwnVector<DTRecHit1DPair,edm::ClonePolicy<DTRecHit1DPair> >,edm::ClonePolicy<DTRecHit1DPair> >"/> 
+  <ioread sourceClass="edm::RangeMap<DTLayerId, edm::OwnVector<DTRecHit1DPair, edm::ClonePolicy<DTRecHit1DPair> >, edm::ClonePolicy<DTRecHit1DPair> >" targetClass="edm::RangeMap<DTLayerId, edm::OwnVector<DTRecHit1DPair, edm::ClonePolicy<DTRecHit1DPair> >, edm::ClonePolicy<DTRecHit1DPair> >" version="[1-10]" source="edm::OwnVector<DTRecHit1DPair> collection_" target="collection_">
+  <![CDATA[
+          collection_ = edm::detail::io_transform(onfile.collection_);
+]]>
+  </ioread>
   <class name="edm::Wrapper<edm::RangeMap <DTLayerId, edm::OwnVector<DTRecHit1DPair,edm::ClonePolicy<DTRecHit1DPair> >,edm::ClonePolicy<DTRecHit1DPair> > >"/>
   <class name="std::vector<DTRecHit1D>"/>
   <class name="std::vector<DTRecHit1DPair>"/>
@@ -52,6 +57,7 @@
    <version ClassVersion="10" checksum="2324947244"/>
   </class>
   <class name="std::vector<DTRecSegment4D*>"/>
+  <class name="std::vector<DTRecSegment4D>"/>
   <class name="std::map<DTChamberId,std::pair<unsigned int,unsigned int> >"/>
   <class name="std::pair<DTChamberId,std::pair<unsigned int,unsigned int> >"/>
   <class name="std::map<DTChamberId,std::pair<unsigned long,unsigned long> >"/>
@@ -59,6 +65,11 @@
   <class name="edm::OwnVector<DTRecSegment4D,edm::ClonePolicy<DTRecSegment4D> >"/>
   <class name="edm::ClonePolicy<DTRecSegment4D>" /> <!-- Root6 -->
   <class name="edm::RangeMap <DTChamberId, edm::OwnVector<DTRecSegment4D,edm::ClonePolicy<DTRecSegment4D> >,edm::ClonePolicy<DTRecSegment4D> >"/>
+  <ioread sourceClass="edm::RangeMap<DTChamberId, edm::OwnVector<DTRecSegment4D, edm::ClonePolicy<DTRecSegment4D> >, edm::ClonePolicy<DTRecSegment4D> >" targetClass="edm::RangeMap<DTChamberId, edm::OwnVector<DTRecSegment4D, edm::ClonePolicy<DTRecSegment4D> >, edm::ClonePolicy<DTRecSegment4D> >" version="[1-10]" source="edm::OwnVector<DTRecSegment4D> collection_" target="collection_">
+  <![CDATA[
+          collection_ = edm::detail::io_transform(onfile.collection_);
+]]>
+  </ioread>
   <class name="edm::Wrapper<edm::RangeMap <DTChamberId, edm::OwnVector<DTRecSegment4D,edm::ClonePolicy<DTRecSegment4D> >,edm::ClonePolicy<DTRecSegment4D> > >"/>
   <class name="DTRecSegment4DRef"/>
 </selection>

--- a/DataFormats/EgammaCandidates/interface/Conversion.h
+++ b/DataFormats/EgammaCandidates/interface/Conversion.h
@@ -42,7 +42,7 @@ namespace reco {
     Conversion();
 
     Conversion(const reco::CaloClusterPtrVector& clu,
-               const std::vector<edm::RefToBase<reco::Track> >& tr,
+               const std::vector<edm::Ptr<reco::Track> >& tr,
                const std::vector<math::XYZPointF>& trackPositionAtEcal,
                const reco::Vertex& convVtx,
                const std::vector<reco::CaloClusterPtr>& matchingBC,
@@ -74,7 +74,7 @@ namespace reco {
                ConversionAlgorithm = undefined);
 
     Conversion(const reco::CaloClusterPtrVector& clu,
-               const std::vector<edm::RefToBase<reco::Track> >& tr,
+               const std::vector<edm::Ptr<reco::Track> >& tr,
                const reco::Vertex& convVtx,
                ConversionAlgorithm = undefined);
 
@@ -83,7 +83,7 @@ namespace reco {
     /// Pointer to CaloCluster (foe Egamma Conversions it points to  a SuperCluster)
     reco::CaloClusterPtrVector caloCluster() const { return caloCluster_; }
     /// vector of track to base references
-    std::vector<edm::RefToBase<reco::Track> > const& tracks() const;
+    std::vector<edm::Ptr<reco::Track> > const& tracks() const;
     /// returns  the reco conversion vertex
     const reco::Vertex& conversionVertex() const { return theConversionVertex_; }
     /// Bool flagging objects having track size >0
@@ -182,7 +182,7 @@ namespace reco {
     /// vector pointer to a/multiple seed CaloCluster(s)
     reco::CaloClusterPtrVector caloCluster_;
     /// vector Track RefToBase
-    std::vector<edm::RefToBase<reco::Track> > trackToBaseRefs_;
+    std::vector<edm::Ptr<reco::Track> > trackToBaseRefs_;
     /// position at the ECAl surface of the track extrapolation
     std::vector<math::XYZPointF> thePositionAtEcal_;
     /// Fitted Kalman conversion vertex

--- a/DataFormats/EgammaCandidates/interface/GsfElectron.h
+++ b/DataFormats/EgammaCandidates/interface/GsfElectron.h
@@ -15,6 +15,7 @@
 //#include "DataFormats/Math/interface/LorentzVector.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/GeometryVector/interface/GlobalVector.h"
+#include "DataFormats/Common/interface/Ptr.h"
 #include <vector>
 #include <limits>
 #include <numeric>
@@ -63,7 +64,7 @@ namespace reco {
                 const GsfElectronCoreRef &core,
                 const CaloClusterPtr &electronCluster,
                 const TrackRef &closestCtfTrack,
-                const TrackBaseRef &conversionPartner,
+                const edm::Ptr<Track> &conversionPartner,
                 const GsfTrackRefVector &ambiguousTracks);
     GsfElectron(int charge,
                 const ChargeInfo &,
@@ -89,7 +90,7 @@ namespace reco {
     GsfElectron *clone(const GsfElectronCoreRef &core,
                        const CaloClusterPtr &electronCluster,
                        const TrackRef &closestCtfTrack,
-                       const TrackBaseRef &conversionPartner,
+                       const edm::Ptr<Track> &conversionPartner,
                        const GsfTrackRefVector &ambiguousTracks) const;
     ~GsfElectron() override{};
 
@@ -626,7 +627,7 @@ namespace reco {
   public:
     struct ConversionRejection {
       int flags;             // -max:not-computed, other: as computed by Puneeth conversion code
-      TrackBaseRef partner;  // conversion partner
+      edm::Ptr<reco::Track> partner;  // conversion partner
       float dist;            // distance to the conversion partner
       float dcot;            // difference of cot(angle) with the conversion partner track
       float radius;          // signed conversion radius
@@ -641,7 +642,7 @@ namespace reco {
 
     // accessors
     int convFlags() const { return conversionRejection_.flags; }
-    TrackBaseRef convPartner() const { return conversionRejection_.partner; }
+    edm::Ptr<reco::Track> convPartner() const { return conversionRejection_.partner; }
     float convDist() const { return conversionRejection_.dist; }
     float convDcot() const { return conversionRejection_.dcot; }
     float convRadius() const { return conversionRejection_.radius; }

--- a/DataFormats/EgammaCandidates/interface/Photon.h
+++ b/DataFormats/EgammaCandidates/interface/Photon.h
@@ -85,7 +85,7 @@ namespace reco {
       else
         return false;
     }
-    int conversionTrackProvenance(const edm::RefToBase<reco::Track>& convTrack) const;
+    int conversionTrackProvenance(const edm::Ptr<reco::Track>& convTrack) const;
 
     /// position in ECAL: this is th SC position if r9<0.93. If r8>0.93 is position of seed BasicCluster taking shower depth for unconverted photon
     math::XYZPointF caloPosition() const { return caloPosition_; }

--- a/DataFormats/EgammaCandidates/src/Conversion.cc
+++ b/DataFormats/EgammaCandidates/src/Conversion.cc
@@ -2,6 +2,7 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
 #include "CLHEP/Units/GlobalPhysicalConstants.h"
+#include "DataFormats/Common/interface/RefToPtr.h"
 
 using namespace reco;
 
@@ -33,12 +34,12 @@ Conversion::Conversion(const reco::CaloClusterPtrVector& sc,
       algorithm_(algo) {
   trackToBaseRefs_.reserve(tr.size());
   for (auto const& track : tr) {
-    trackToBaseRefs_.emplace_back(track);
+    trackToBaseRefs_.emplace_back(edm::refToPtr(track));
   }
 }
 
 Conversion::Conversion(const reco::CaloClusterPtrVector& sc,
-                       const std::vector<edm::RefToBase<reco::Track> >& tr,
+                       const std::vector<edm::Ptr<reco::Track> >& tr,
                        const std::vector<math::XYZPointF>& trackPositionAtEcal,
                        const reco::Vertex& convVtx,
                        const std::vector<reco::CaloClusterPtr>& matchingBC,
@@ -81,7 +82,7 @@ Conversion::Conversion(const reco::CaloClusterPtrVector& sc,
       algorithm_(algo) {
   trackToBaseRefs_.reserve(tr.size());
   for (auto const& track : tr) {
-    trackToBaseRefs_.emplace_back(track);
+    trackToBaseRefs_.emplace_back(edm::refToPtr(track));
   }
 
   theMinDistOfApproach_ = 9999.;
@@ -97,7 +98,7 @@ Conversion::Conversion(const reco::CaloClusterPtrVector& sc,
 }
 
 Conversion::Conversion(const reco::CaloClusterPtrVector& sc,
-                       const std::vector<edm::RefToBase<reco::Track> >& tr,
+                       const std::vector<edm::Ptr<reco::Track> >& tr,
                        const reco::Vertex& convVtx,
                        ConversionAlgorithm algo)
     : caloCluster_(sc),
@@ -147,7 +148,7 @@ Conversion::ConversionAlgorithm Conversion::algoByName(const std::string& name) 
 
 Conversion* Conversion::clone() const { return new Conversion(*this); }
 
-std::vector<edm::RefToBase<reco::Track> > const& Conversion::tracks() const { return trackToBaseRefs_; }
+std::vector<edm::Ptr<reco::Track> > const& Conversion::tracks() const { return trackToBaseRefs_; }
 
 bool Conversion::isConverted() const {
   if (this->nTracks() == 2)

--- a/DataFormats/EgammaCandidates/src/GsfElectron.cc
+++ b/DataFormats/EgammaCandidates/src/GsfElectron.cc
@@ -106,7 +106,7 @@ GsfElectron::GsfElectron(const GsfElectron& electron,
                          const GsfElectronCoreRef& core,
                          const CaloClusterPtr& electronCluster,
                          const TrackRef& closestCtfTrack,
-                         const TrackBaseRef& conversionPartner,
+                         const edm::Ptr<Track>& conversionPartner,
                          const GsfTrackRefVector& ambiguousTracks)
     : RecoCandidate(electron),
       chargeInfo_(electron.chargeInfo_),
@@ -160,7 +160,7 @@ GsfElectron* GsfElectron::clone() const { return new GsfElectron(*this); }
 GsfElectron* GsfElectron::clone(const GsfElectronCoreRef& core,
                                 const CaloClusterPtr& electronCluster,
                                 const TrackRef& closestCtfTrack,
-                                const TrackBaseRef& conversionPartner,
+                                const edm::Ptr<Track>& conversionPartner,
                                 const GsfTrackRefVector& ambiguousTracks) const {
   return new GsfElectron(*this, core, electronCluster, closestCtfTrack, conversionPartner, ambiguousTracks);
 }

--- a/DataFormats/EgammaCandidates/src/GsfElectronCore.cc
+++ b/DataFormats/EgammaCandidates/src/GsfElectronCore.cc
@@ -13,12 +13,12 @@ GsfElectronCore::GsfElectronCore() : ctfGsfOverlap_(0.), isEcalDrivenSeed_(false
 
 GsfElectronCore::GsfElectronCore(const GsfTrackRef& gsfTrack)
     : gsfTrack_(gsfTrack), ctfGsfOverlap_(0.), isEcalDrivenSeed_(false), isTrackerDrivenSeed_(false) {
-  edm::RefToBase<TrajectorySeed> seed = gsfTrack_->extra()->seedRef();
+  edm::Ptr<TrajectorySeed> seed = gsfTrack_->extra()->seedRef();
   if (seed.isNull()) {
     edm::LogError("GsfElectronCore") << "The GsfTrack has no seed ?!";
   } else {
-    ElectronSeedRef elseed = seed.castTo<ElectronSeedRef>();
-    if (elseed.isNull()) {
+    ElectronSeed const* elseed = dynamic_cast<ElectronSeed const*>(seed.get());
+    if (not elseed) {
       edm::LogError("GsfElectronCore") << "The GsfTrack seed is not an ElectronSeed ?!";
     } else {
       if (elseed->isEcalDriven())

--- a/DataFormats/EgammaCandidates/src/Photon.cc
+++ b/DataFormats/EgammaCandidates/src/Photon.cc
@@ -48,7 +48,7 @@ void Photon::setVertex(const Point& vertex) {
 
 reco::SuperClusterRef Photon::superCluster() const { return this->photonCore()->superCluster(); }
 
-int Photon::conversionTrackProvenance(const edm::RefToBase<reco::Track>& convTrack) const {
+int Photon::conversionTrackProvenance(const edm::Ptr<reco::Track>& convTrack) const {
   const reco::ConversionRefVector& conv2leg = this->photonCore()->conversions();
   const reco::ConversionRefVector& conv1leg = this->photonCore()->conversionsOneLeg();
 
@@ -56,7 +56,7 @@ int Photon::conversionTrackProvenance(const edm::RefToBase<reco::Track>& convTra
   bool isEg = false, isPf = false;
 
   for (unsigned iConv = 0; iConv < conv2leg.size(); iConv++) {
-    std::vector<edm::RefToBase<reco::Track> > convtracks = conv2leg[iConv]->tracks();
+    std::vector<edm::Ptr<reco::Track> > convtracks = conv2leg[iConv]->tracks();
     for (unsigned itk = 0; itk < convtracks.size(); itk++) {
       if (convTrack == convtracks[itk])
         isEg = true;
@@ -64,7 +64,7 @@ int Photon::conversionTrackProvenance(const edm::RefToBase<reco::Track>& convTra
   }
 
   for (unsigned iConv = 0; iConv < conv1leg.size(); iConv++) {
-    std::vector<edm::RefToBase<reco::Track> > convtracks = conv1leg[iConv]->tracks();
+    std::vector<edm::Ptr<reco::Track> > convtracks = conv1leg[iConv]->tracks();
     for (unsigned itk = 0; itk < convtracks.size(); itk++) {
       if (convTrack == convtracks[itk])
         isPf = true;

--- a/DataFormats/EgammaCandidates/src/classes.h
+++ b/DataFormats/EgammaCandidates/src/classes.h
@@ -36,6 +36,8 @@
 #include "DataFormats/Common/interface/Ptr.h"
 #include "DataFormats/Common/interface/PtrVector.h"
 #include "DataFormats/Common/interface/ValueMap.h"
+#include "DataFormats/Common/interface/RefToBaseToPtr_ioread.h"
+#include "DataFormats/Common/interface/RefToPtr.h"
 #include "Rtypes.h"
 #include "Math/Cartesian3D.h"
 #include "Math/Polar3D.h"

--- a/DataFormats/EgammaCandidates/src/classes_def.xml
+++ b/DataFormats/EgammaCandidates/src/classes_def.xml
@@ -17,12 +17,26 @@
    <version ClassVersion="13" checksum="2963666409"/>
    <version ClassVersion="14" checksum="753726370"/>
   </class>
-  <class name="reco::Conversion" ClassVersion="11">
-   <version ClassVersion="10" checksum="2140222741"/>
+  <class name="reco::Conversion" ClassVersion="12">
+   <version ClassVersion="12" checksum="3945296887"/>
    <version ClassVersion="11" checksum="598717096"/>
+   <version ClassVersion="10" checksum="2140222741"/>
   </class>
+  <ioread sourceClass = "reco::Conversion" version="[11]" targetClass="reco::Conversion" source="std::vector<edm::RefToBase<reco::Track> > trackToBaseRefs_" target="trackToBaseRefs_">
+     <![CDATA[
+              std::transform(onfile.trackToBaseRefs_.begin(), onfile.trackToBaseRefs_.end(), 
+                             std::back_inserter(trackToBaseRefs_), [](auto const& iOld) {  
+                             return edm::refToBaseToPtr_ioread(iOld);
+                             });
+     ]]>
+  </ioread>
   <ioread sourceClass = "reco::Conversion" version="[1-10]" targetClass="reco::Conversion" source="std::vector<reco::TrackRef> tracks_; std::vector<edm::RefToBase<reco::Track> > trackToBaseRefs_" target="trackToBaseRefs_">
-     <![CDATA[trackToBaseRefs_=onfile.trackToBaseRefs_; if(onfile.tracks_.size()>onfile.trackToBaseRefs_.size()) { for(auto const& t: onfile.tracks_) { trackToBaseRefs_.emplace_back(t);} }]]>
+     <![CDATA[
+              std::transform(onfile.trackToBaseRefs_.begin(), onfile.trackToBaseRefs_.end(), 
+                             std::back_inserter(trackToBaseRefs_), [](auto const& iOld) {  
+                             return edm::refToBaseToPtr_ioread(iOld);
+                             });
+             if(onfile.tracks_.size()>onfile.trackToBaseRefs_.size()) { for(auto const& t: onfile.tracks_) { trackToBaseRefs_.emplace_back(edm::refToPtr(t));} }]]>
   </ioread>
   <class name="reco::Electron" ClassVersion="13">
    <version ClassVersion="13" checksum="827670837"/>
@@ -176,10 +190,17 @@
    <version ClassVersion="11" checksum="1799511018"/>
    <version ClassVersion="10" checksum="4260674990"/>
   </class>
-  <class name="reco::GsfElectron::ConversionRejection" ClassVersion="11">
+  <class name="reco::GsfElectron::ConversionRejection" ClassVersion="12">
+    <version ClassVersion="12" checksum="2742251964"/>
    <version ClassVersion="11" checksum="2813508647"/>
    <version ClassVersion="10" checksum="190549577"/>
   </class>
+  <ioread sourceClass = "reco::GsfElectron::ConversionRejection" version="[1-11]" targetClass="reco::GsfElectron::ConversionRejection" source="edm::RefToBase<reco::Track> partner" target="partner">
+   <![CDATA[
+     partner = edm::refToBaseToPtr_ioread(onfile.partner);
+      ]]>
+ </ioread>
+
   <class name="reco::GsfElectron::Corrections" ClassVersion="12">
    <version ClassVersion="12" checksum="796270676"/>
    <version ClassVersion="11" checksum="4279379731"/>

--- a/DataFormats/GEMRecHit/interface/GEMCSCSegmentCollection.h
+++ b/DataFormats/GEMRecHit/interface/GEMCSCSegmentCollection.h
@@ -17,6 +17,12 @@
 #include "DataFormats/Common/interface/ClonePolicy.h"
 #include "DataFormats/Common/interface/OwnVector.h"
 
+namespace edm::detail {
+  template<>
+    struct RangeMapContainer<edm::OwnVector<GEMCSCSegment>> {
+    using type = edm::OwnVector<GEMCSCSegment>;
+  };
+}
 typedef edm::RangeMap<CSCDetId, edm::OwnVector<GEMCSCSegment> > GEMCSCSegmentCollection;
 
 #include "DataFormats/Common/interface/Ref.h"

--- a/DataFormats/GEMRecHit/interface/GEMRecHitCollection.h
+++ b/DataFormats/GEMRecHit/interface/GEMRecHitCollection.h
@@ -14,6 +14,12 @@
 #include "DataFormats/Common/interface/OwnVector.h"
 #include <functional>
 
+namespace edm::detail {
+  template<>
+    struct RangeMapContainer<edm::OwnVector<GEMRecHit>> {
+    using type = std::vector<GEMRecHit>;
+  };
+}
 typedef edm::RangeMap<GEMDetId, edm::OwnVector<GEMRecHit, edm::ClonePolicy<GEMRecHit> >, edm::ClonePolicy<GEMRecHit> >
     GEMRecHitCollection;
 

--- a/DataFormats/GEMRecHit/interface/GEMSegmentCollection.h
+++ b/DataFormats/GEMRecHit/interface/GEMSegmentCollection.h
@@ -15,6 +15,13 @@
 #include "DataFormats/Common/interface/ClonePolicy.h"
 #include "DataFormats/Common/interface/OwnVector.h"
 
+namespace edm::detail {
+  template<>
+    struct RangeMapContainer<edm::OwnVector<GEMSegment>> {
+    using type = std::vector<GEMSegment>;
+  };
+}
+
 typedef edm::RangeMap<GEMDetId, edm::OwnVector<GEMSegment> > GEMSegmentCollection;
 
 #include "DataFormats/Common/interface/Ref.h"

--- a/DataFormats/GEMRecHit/interface/ME0RecHitCollection.h
+++ b/DataFormats/GEMRecHit/interface/ME0RecHitCollection.h
@@ -16,6 +16,13 @@
 #include "DataFormats/Common/interface/OwnVector.h"
 #include <functional>
 
+namespace edm::detail {
+  template<>
+    struct RangeMapContainer<edm::OwnVector<ME0RecHit>> {
+    using type = std::vector<ME0RecHit>;
+  };
+}
+
 typedef edm::RangeMap<ME0DetId, edm::OwnVector<ME0RecHit, edm::ClonePolicy<ME0RecHit> >, edm::ClonePolicy<ME0RecHit> >
     ME0RecHitCollection;
 

--- a/DataFormats/GEMRecHit/interface/ME0SegmentCollection.h
+++ b/DataFormats/GEMRecHit/interface/ME0SegmentCollection.h
@@ -16,6 +16,12 @@
 #include "DataFormats/Common/interface/ClonePolicy.h"
 #include "DataFormats/Common/interface/OwnVector.h"
 
+namespace edm::detail {
+  template<>
+    struct RangeMapContainer<edm::OwnVector<ME0Segment>> {
+    using type = std::vector<ME0Segment>;
+  };
+}
 typedef edm::RangeMap<ME0DetId, edm::OwnVector<ME0Segment> > ME0SegmentCollection;
 
 #include "DataFormats/Common/interface/Ref.h"

--- a/DataFormats/JetReco/interface/JPTJet.h
+++ b/DataFormats/JetReco/interface/JPTJet.h
@@ -23,6 +23,7 @@
 #include "DataFormats/CaloTowers/interface/CaloTowerCollection.h"
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/RefVector.h"
+#include "DataFormats/Common/interface/Ptr.h"
 
 namespace reco {
   class JPTJet : public Jet {
@@ -43,7 +44,7 @@ namespace reco {
             Pout(0),
             Zch(0),
             JPTSeed(0) {}
-      edm::RefToBase<reco::Jet> theCaloJetRef;
+      edm::Ptr<reco::Jet> theCaloJetRef;
       reco::TrackRefVector pionsInVertexInCalo;
       reco::TrackRefVector pionsInVertexOutCalo;
       reco::TrackRefVector pionsOutVertexInCalo;
@@ -115,7 +116,7 @@ namespace reco {
     const reco::TrackRefVector& getElecsInVertexOutCalo() const { return mspecific.elecsInVertexOutCalo; }
     const reco::TrackRefVector& getElecsOutVertexInCalo() const { return mspecific.elecsOutVertexInCalo; }
 
-    const edm::RefToBase<reco::Jet>& getCaloJetRef() const { return mspecific.theCaloJetRef; }
+    const edm::Ptr<reco::Jet>& getCaloJetRef() const { return mspecific.theCaloJetRef; }
     /// block accessors
 
     const Specific& getSpecific() const { return mspecific; }

--- a/DataFormats/JetReco/src/classes_1.h
+++ b/DataFormats/JetReco/src/classes_1.h
@@ -22,5 +22,6 @@
 
 #include "DataFormats/Common/interface/PtrVector.h"
 #include "DataFormats/Common/interface/Ptr.h"
+#include "DataFormats/Common/interface/RefToBaseToPtr_ioread.h"
 
 #endif

--- a/DataFormats/JetReco/src/classes_def_1.xml
+++ b/DataFormats/JetReco/src/classes_def_1.xml
@@ -47,10 +47,18 @@
    <version ClassVersion="11" checksum="2945806860"/>
    <version ClassVersion="10" checksum="456342263"/>
   </class>
-  <class name="reco::JPTJet::Specific" ClassVersion="11">
+  <class name="reco::JPTJet::Specific" ClassVersion="12">
+    <version ClassVersion="12" checksum="3058414397"/>
    <version ClassVersion="11" checksum="3661452230"/>
    <version ClassVersion="10" checksum="3095396018"/>
   </class>
+  <ioread sourceClass = "reco::JPTJet::Specific" version="[1-11]" targetClass="reco::JPTJet::Specific" source="edm::RefToBase<reco::Jet> theCaloJetRef" target="theCaloJetRef">                                                                       
+   <![CDATA[
+     theCaloJetRef = edm::refToBaseToPtr_ioread(onfile.theCaloJetRef);
+      ]]>
+ </ioread>
+
+  
   <class name="std::vector<reco::JPTJet>"/>
   <class name="edm::RefProd<std::vector<reco::JPTJet> >"/>
   <class name="edm::RefVector<std::vector<reco::JPTJet>,reco::JPTJet,edm::refhelper::FindUsingAdvance<std::vector<reco::JPTJet>,reco::JPTJet> >"/>

--- a/DataFormats/MuonReco/src/classes_def.xml
+++ b/DataFormats/MuonReco/src/classes_def.xml
@@ -65,7 +65,8 @@ initial version number of a class which has never been stored before.
    <version ClassVersion="11" checksum="541727491"/>
    <version ClassVersion="10" checksum="4050071853"/>
   </class>
-  <class name="reco::MuonSegmentMatch" ClassVersion="11">
+  <class name="reco::MuonSegmentMatch" ClassVersion="12">
+    <version ClassVersion="12" checksum="534090338"/>
     <version ClassVersion="11" checksum="2861296960"/>
     <version ClassVersion="10" checksum="754193003"/>    
   </class>

--- a/DataFormats/MuonReco/src/classes_def.xml
+++ b/DataFormats/MuonReco/src/classes_def.xml
@@ -65,8 +65,7 @@ initial version number of a class which has never been stored before.
    <version ClassVersion="11" checksum="541727491"/>
    <version ClassVersion="10" checksum="4050071853"/>
   </class>
-  <class name="reco::MuonSegmentMatch" ClassVersion="12">
-    <version ClassVersion="12" checksum="534090338"/>
+  <class name="reco::MuonSegmentMatch" ClassVersion="11">
     <version ClassVersion="11" checksum="2861296960"/>
     <version ClassVersion="10" checksum="754193003"/>    
   </class>

--- a/DataFormats/ParticleFlowCandidate/interface/PFCandidate.h
+++ b/DataFormats/ParticleFlowCandidate/interface/PFCandidate.h
@@ -550,7 +550,7 @@ namespace reco {
 
     const edm::EDProductGetter* getter_;  //transient
     unsigned short storedRefsBitPattern_;
-    std::vector<unsigned long long> refsInfo_;
+    std::vector<uint64_t> refsInfo_;
     std::vector<const void*> refsCollectionCache_;
 
     /// timing information (valid if timeError_ >= 0)

--- a/DataFormats/ParticleFlowCandidate/src/classes_def.xml
+++ b/DataFormats/ParticleFlowCandidate/src/classes_def.xml
@@ -1,6 +1,7 @@
 <lcgdict>
 
-   <class name="reco::PFCandidate" ClassVersion="20">
+   <class name="reco::PFCandidate" ClassVersion="21">
+    <version ClassVersion="21" checksum="3229383209"/>
     <version ClassVersion="20" checksum="2748489940"/>
     <version ClassVersion="19" checksum="2990582232"/>
     <version ClassVersion="18" checksum="910857761"/>
@@ -54,7 +55,8 @@
   <class name="edm::PtrVector<reco::PFCandidate> "/>
   <class name="edm::Wrapper<edm::PtrVector<reco::PFCandidate> >"/>
 
-  <class name="reco::IsolatedPFCandidate"  ClassVersion="16">
+  <class name="reco::IsolatedPFCandidate"  ClassVersion="17">
+   <version ClassVersion="17" checksum="1577661194"/>
    <version ClassVersion="16" checksum="2274533749"/>
    <version ClassVersion="15" checksum="3042264953"/>
    <version ClassVersion="14" checksum="207328514"/>
@@ -70,7 +72,8 @@
   <class name="reco::IsolatedPFCandidateRefVector"/>
   <class name="reco::IsolatedPFCandidatePtr"/>
 
-  <class name="reco::PileUpPFCandidate"  ClassVersion="16">
+  <class name="reco::PileUpPFCandidate"  ClassVersion="17">
+   <version ClassVersion="17" checksum="4136569255"/>
    <version ClassVersion="16" checksum="3331568330"/>
    <version ClassVersion="15" checksum="953549166"/>
    <version ClassVersion="14" checksum="4065938015"/>

--- a/DataFormats/ParticleFlowCandidate/src/classes_def.xml
+++ b/DataFormats/ParticleFlowCandidate/src/classes_def.xml
@@ -1,7 +1,7 @@
 <lcgdict>
 
    <class name="reco::PFCandidate" ClassVersion="21">
-    <version ClassVersion="21" checksum="3229383209"/>
+    <version ClassVersion="21" checksum="3398273330"/>
     <version ClassVersion="20" checksum="2748489940"/>
     <version ClassVersion="19" checksum="2990582232"/>
     <version ClassVersion="18" checksum="910857761"/>
@@ -56,7 +56,7 @@
   <class name="edm::Wrapper<edm::PtrVector<reco::PFCandidate> >"/>
 
   <class name="reco::IsolatedPFCandidate"  ClassVersion="17">
-   <version ClassVersion="17" checksum="1577661194"/>
+   <version ClassVersion="17" checksum="3339621203"/>
    <version ClassVersion="16" checksum="2274533749"/>
    <version ClassVersion="15" checksum="3042264953"/>
    <version ClassVersion="14" checksum="207328514"/>
@@ -73,7 +73,7 @@
   <class name="reco::IsolatedPFCandidatePtr"/>
 
   <class name="reco::PileUpPFCandidate"  ClassVersion="17">
-   <version ClassVersion="17" checksum="4136569255"/>
+   <version ClassVersion="17" checksum="2415579992"/>
    <version ClassVersion="16" checksum="3331568330"/>
    <version ClassVersion="15" checksum="953549166"/>
    <version ClassVersion="14" checksum="4065938015"/>

--- a/DataFormats/ParticleFlowReco/interface/PFDisplacedTrackerVertex.h
+++ b/DataFormats/ParticleFlowReco/interface/PFDisplacedTrackerVertex.h
@@ -10,6 +10,7 @@
 #include "DataFormats/ParticleFlowReco/interface/PFDisplacedVertexFwd.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecTrack.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecTrackFwd.h"
+#include "DataFormats/Common/interface/RefToPtr.h"
 
 namespace reco {
   class PFDisplacedTrackerVertex {
@@ -21,13 +22,11 @@ namespace reco {
     const PFRecTrackRefVector& pfRecTracks() const { return pfRecTracks_; }
 
     const bool isIncomingTrack(const reco::PFRecTrackRef originalTrack) const {
-      reco::TrackBaseRef trackBaseRef(originalTrack->trackRef());
-      return displacedVertexRef_->isIncomingTrack(trackBaseRef);
+      return displacedVertexRef_->isIncomingTrack(edm::refToPtr(originalTrack->trackRef()));
     }
 
     const bool isOutgoingTrack(const reco::PFRecTrackRef originalTrack) const {
-      reco::TrackBaseRef trackBaseRef(originalTrack->trackRef());
-      return displacedVertexRef_->isOutgoingTrack(trackBaseRef);
+      return displacedVertexRef_->isOutgoingTrack(edm::refToPtr(originalTrack->trackRef()));
     }
 
     const PFDisplacedVertexRef& displacedVertexRef() const { return displacedVertexRef_; }

--- a/DataFormats/ParticleFlowReco/interface/PFDisplacedVertex.h
+++ b/DataFormats/ParticleFlowReco/interface/PFDisplacedVertex.h
@@ -64,7 +64,7 @@ namespace reco {
     PFDisplacedVertex(reco::Vertex&);
 
     /// Add a new track to the vertex
-    void addElement(const TrackBaseRef& r,
+    void addElement(const edm::Ptr<reco::Track>& r,
                     const Track& refTrack,
                     const PFTrackHitFullInfo& hitInfo,
                     VertexTrackType trackType = T_NOT_FROM_VERTEX,
@@ -102,36 +102,36 @@ namespace reco {
     const bool isThereNotFromVertexTracks() const { return isThereKindTracks(T_NOT_FROM_VERTEX); }
 
     /// Is a primary track was identified
-    const bool isPrimaryTrack(const reco::TrackBaseRef& originalTrack) const {
+    const bool isPrimaryTrack(const edm::Ptr<reco::Track>& originalTrack) const {
       size_t itrk = trackPosition(originalTrack);
       return isTrack(itrk, T_TO_VERTEX);
     }
 
     /// Is a secondary track was identified
-    const bool isSecondaryTrack(const reco::TrackBaseRef& originalTrack) const {
+    const bool isSecondaryTrack(const edm::Ptr<reco::Track>& originalTrack) const {
       size_t itrk = trackPosition(originalTrack);
       return isTrack(itrk, T_FROM_VERTEX);
     }
 
     /// Is a secondary track was identified
-    const bool isMergedTrack(const reco::TrackBaseRef& originalTrack) const {
+    const bool isMergedTrack(const edm::Ptr<reco::Track>& originalTrack) const {
       size_t itrk = trackPosition(originalTrack);
       return isTrack(itrk, T_MERGED);
     }
 
-    const PFTrackHitFullInfo trackHitFullInfo(const reco::TrackBaseRef& originalTrack) const {
+    const PFTrackHitFullInfo trackHitFullInfo(const edm::Ptr<reco::Track>& originalTrack) const {
       size_t itrk = trackPosition(originalTrack);
       return trackHitFullInfos_[itrk];
     }
 
     /// Is primary or merged track
-    const bool isIncomingTrack(const reco::TrackBaseRef& originalTrack) const {
+    const bool isIncomingTrack(const edm::Ptr<reco::Track>& originalTrack) const {
       size_t itrk = trackPosition(originalTrack);
       return isTrack(itrk, T_MERGED) || isTrack(itrk, T_TO_VERTEX);
     }
 
     /// Is secondary track
-    const bool isOutgoingTrack(const reco::TrackBaseRef& originalTrack) const {
+    const bool isOutgoingTrack(const edm::Ptr<reco::Track>& originalTrack) const {
       size_t itrk = trackPosition(originalTrack);
       return isTrack(itrk, T_FROM_VERTEX);
     }
@@ -151,7 +151,7 @@ namespace reco {
     /// Number of tracks
     const int nTracks() const { return trackTypes_.size(); }
 
-    //    const reco::VertexTrackType vertexTrackType(reco::TrackBaseRef tkRef) const;
+    //    const reco::VertexTrackType vertexTrackType(edm::Ptr<reco::Track> tkRef) const;
 
     /// Momentum of secondary tracks calculated with a mass hypothesis. Some of those
     /// hypothesis are default: "PI" , "KAON", "LAMBDA", "MASSLESS", "CUSTOM"
@@ -241,7 +241,7 @@ namespace reco {
     /// Get the mass with a given hypothesis
     const double getMass2(M_Hypo, double) const;
 
-    const size_t trackPosition(const reco::TrackBaseRef& originalTrack) const;
+    const size_t trackPosition(const edm::Ptr<reco::Track>& originalTrack) const;
 
     const bool isTrack(size_t itrk, VertexTrackType T) const { return trackTypes_[itrk] == T; }
 

--- a/DataFormats/ParticleFlowReco/interface/PFNuclearInteraction.h
+++ b/DataFormats/ParticleFlowReco/interface/PFNuclearInteraction.h
@@ -23,7 +23,7 @@ namespace reco {
         : nuclInterRef_(nuclref), pfSecTracks_(pfSeconds) {}
 
     /// \return the base reference to the primary track
-    const edm::RefToBase<reco::Track>& primaryTrack() const { return nuclInterRef_->primaryTrack(); }
+    const edm::Ptr<reco::Track>& primaryTrack() const { return nuclInterRef_->primaryTrack(); }
 
     /// \return first iterator over secondary tracks
     trackRef_iterator secondaryTracks_begin() const { return nuclInterRef_->secondaryTracks_begin(); }

--- a/DataFormats/ParticleFlowReco/src/PFDisplacedVertex.cc
+++ b/DataFormats/ParticleFlowReco/src/PFDisplacedVertex.cc
@@ -9,7 +9,7 @@ PFDisplacedVertex::PFDisplacedVertex() : Vertex(), vertexType_(ANY), primaryDire
 
 PFDisplacedVertex::PFDisplacedVertex(Vertex& v) : Vertex(v), vertexType_(ANY), primaryDirection_(0, 0, 0) {}
 
-void PFDisplacedVertex::addElement(const TrackBaseRef& r,
+void PFDisplacedVertex::addElement(const edm::Ptr<reco::Track>& r,
                                    const Track& refTrack,
                                    const PFTrackHitFullInfo& hitInfo,
                                    VertexTrackType trackType,
@@ -34,7 +34,7 @@ const int PFDisplacedVertex::nKindTracks(VertexTrackType T) const {
   return count(trackTypes_.begin(), trackTypes_.end(), T);
 }
 
-const size_t PFDisplacedVertex::trackPosition(const reco::TrackBaseRef& originalTrack) const {
+const size_t PFDisplacedVertex::trackPosition(const edm::Ptr<reco::Track>& originalTrack) const {
   size_t pos = -1;
 
   const Track refittedTrack = PFDisplacedVertex::refittedTrack(originalTrack);
@@ -136,7 +136,7 @@ const math::XYZTLorentzVector PFDisplacedVertex::momentum(M_Hypo massHypo,
 
     if (bType) {
       if (!useRefitted) {
-        TrackBaseRef trackRef = originalTrack(refittedTracks()[i]);
+        auto trackRef = originalTrack(refittedTracks()[i]);
 
         double p2 = trackRef->momentum().Mag2();
         P += math::XYZTLorentzVector(

--- a/DataFormats/ParticleFlowReco/src/classes_def_2.xml
+++ b/DataFormats/ParticleFlowReco/src/classes_def_2.xml
@@ -245,7 +245,8 @@
   <class name="edm::Wrapper<std::vector<reco::PFDisplacedVertexCandidate> >"/>
   <class name="edm::Ref< std::vector<reco::PFDisplacedVertexCandidate>, reco::PFDisplacedVertexCandidate, edm::refhelper::FindUsingAdvance<std::vector<reco::PFDisplacedVertexCandidate>,reco::PFDisplacedVertexCandidate> >"/>
 
-  <class name="reco::PFDisplacedVertex" ClassVersion="13">
+  <class name="reco::PFDisplacedVertex" ClassVersion="14">
+   <version ClassVersion="14" checksum="2201759015"/>
    <version ClassVersion="13" checksum="3552936040"/>
    <version ClassVersion="12" checksum="2818127737"/>
    <version ClassVersion="11" checksum="4172417049"/>

--- a/DataFormats/PatCandidates/interface/Jet.h
+++ b/DataFormats/PatCandidates/interface/Jet.h
@@ -631,8 +631,7 @@ namespace pat {
 
     std::vector<std::pair<std::string, float> > pairDiscriVector_;
     std::vector<std::string> tagInfoLabels_;
-    edm::OwnVector<reco::BaseTagInfo> tagInfos_;  // Compatibility embedding
-    TagInfoFwdPtrCollection tagInfosFwdPtr_;      // Refactorized embedding
+    TagInfoFwdPtrCollection tagInfosFwdPtr_;  // Refactorized embedding
 
     // ---- track related members ----
 
@@ -659,14 +658,6 @@ namespace pat {
       for (size_t i = 0, n = tagInfosFwdPtr_.size(); i < n; ++i) {
         TagInfoFwdPtrCollection::value_type const& val = tagInfosFwdPtr_[i];
         reco::BaseTagInfo const* baseTagInfo = val.get();
-        if (typeid(*baseTagInfo) == typeid(T)) {
-          return static_cast<const T*>(baseTagInfo);
-        }
-      }
-      // Then check compatibility version
-      for (size_t i = 0, n = tagInfos_.size(); i < n; ++i) {
-        edm::OwnVector<reco::BaseTagInfo>::value_type const& val = tagInfos_[i];
-        reco::BaseTagInfo const* baseTagInfo = &val;
         if (typeid(*baseTagInfo) == typeid(T)) {
           return static_cast<const T*>(baseTagInfo);
         }

--- a/DataFormats/PatCandidates/interface/PATObject.h
+++ b/DataFormats/PatCandidates/interface/PATObject.h
@@ -477,7 +477,6 @@ namespace pat {
 
     /// User data object
     std::vector<std::string> userDataLabels_;
-    pat::UserDataCollection userDataObjects_;
     // User float values
     std::vector<std::string> userFloatLabels_;
     std::vector<float> userFloats_;
@@ -842,10 +841,6 @@ namespace pat {
 
   template <class ObjectType>
   const pat::UserData *PATObject<ObjectType>::userDataObject_(const std::string &key) const {
-    auto it = std::lower_bound(userDataLabels_.cbegin(), userDataLabels_.cend(), key);
-    if (it != userDataLabels_.cend() && *it == key) {
-      return &userDataObjects_[std::distance(userDataLabels_.cbegin(), it)];
-    }
     return nullptr;
   }
 
@@ -853,18 +848,6 @@ namespace pat {
   void PATObject<ObjectType>::addUserDataObject_(const std::string &label,
                                                  std::unique_ptr<pat::UserData> data,
                                                  bool overwrite) {
-    auto it = std::lower_bound(userDataLabels_.begin(), userDataLabels_.end(), label);
-    const auto dist = std::distance(userDataLabels_.begin(), it);
-    if (it == userDataLabels_.end() || *it != label) {
-      userDataLabels_.insert(it, label);
-      userDataObjects_.insert(userDataObjects_.begin() + dist, std::move(data));
-    } else if (overwrite) {
-      userDataObjects_.set(dist, std::move(data));
-    } else {
-      //create a range by adding behind the first entry
-      userDataLabels_.insert(it + 1, label);
-      userDataObjects_.insert(userDataObjects_.begin() + dist + 1, std::move(data));
-    }
   }
 
   template <class ObjectType>

--- a/DataFormats/PatCandidates/interface/Tau.h
+++ b/DataFormats/PatCandidates/interface/Tau.h
@@ -124,7 +124,7 @@ namespace pat {
     const pat::tau::TauPFEssential& pfEssential() const;
     /// Method copied from reco::PFTau.
     /// Throws an exception if this pat::Tau was not made from a reco::PFTau
-    const reco::JetBaseRef& pfJetRef() const { return pfSpecific().pfJetRef_; }
+    const edm::Ptr<reco::Jet>& pfJetRef() const { return pfSpecific().pfJetRef_; }
     /// Method copied from reco::PFTau.
     /// Throws an exception if this pat::Tau was not made from a reco::PFTau
     reco::PFRecoTauChargedHadronRef leadTauChargedHadronCandidate() const;

--- a/DataFormats/PatCandidates/interface/TauPFSpecific.h
+++ b/DataFormats/PatCandidates/interface/TauPFSpecific.h
@@ -15,6 +15,7 @@
 #include "DataFormats/TauReco/interface/PFTauTransverseImpactParameter.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/Common/interface/Ptr.h"
 
 namespace pat {
   namespace tau {
@@ -25,7 +26,7 @@ namespace pat {
       // constructor from PFTau
       TauPFSpecific(const reco::PFTau& tau);
       // datamembers
-      reco::JetBaseRef pfJetRef_;
+      edm::Ptr<reco::Jet> pfJetRef_;
       reco::CandidatePtr leadPFChargedHadrCand_;
       float leadPFChargedHadrCandsignedSipt_;
       reco::PFCandidatePtr leadPFNeutralCand_;

--- a/DataFormats/PatCandidates/interface/TriggerObject.h
+++ b/DataFormats/PatCandidates/interface/TriggerObject.h
@@ -53,7 +53,7 @@ namespace pat {
     /// Reference to trigger object,
     /// meant for 'l1extra' particles to access their additional functionalities,
     /// empty otherwise
-    reco::CandidateBaseRef refToOrig_;
+    reco::CandidatePtr refToOrig_;
 
   public:
     /// Constructors and Destructor
@@ -117,37 +117,39 @@ namespace pat {
     /// Special methods for 'l1extra' particles
 
     /// General getters
-    const reco::CandidateBaseRef& origObjRef() const { return refToOrig_; };
     const reco::Candidate* origObjCand() const { return refToOrig_.get(); };
     /// Getters specific to the 'l1extra' particle type for
     /// - EM
-    const l1extra::L1EmParticleRef origL1EmRef() const;
     const L1GctEmCand* origL1GctEmCand() const {
-      return origL1EmRef().isNonnull() ? origL1EmRef()->gctEmCand() : nullptr;
+      auto* cand = dynamic_cast<const l1extra::L1EmParticle*>(origObjCand());
+      return cand ? cand->gctEmCand() : nullptr;
     };
     /// - EtMiss
-    const l1extra::L1EtMissParticleRef origL1EtMissRef() const;
     const L1GctEtMiss* origL1GctEtMiss() const {
-      return origL1EtMissRef().isNonnull() ? origL1EtMissRef()->gctEtMiss() : nullptr;
+      auto* cand = dynamic_cast<const l1extra::L1EtMissParticle*>(origObjCand());
+      return cand ? cand->gctEtMiss() : nullptr;
     };
     const L1GctEtTotal* origL1GctEtTotal() const {
-      return origL1EtMissRef().isNonnull() ? origL1EtMissRef()->gctEtTotal() : nullptr;
+      auto* cand = dynamic_cast<const l1extra::L1EtMissParticle*>(origObjCand());
+      return cand ? cand->gctEtTotal() : nullptr;
     };
     const L1GctHtMiss* origL1GctHtMiss() const {
-      return origL1EtMissRef().isNonnull() ? origL1EtMissRef()->gctHtMiss() : nullptr;
+      auto* cand = dynamic_cast<const l1extra::L1EtMissParticle*>(origObjCand());
+      return cand ? cand->gctHtMiss() : nullptr;
     };
     const L1GctEtHad* origL1GctEtHad() const {
-      return origL1EtMissRef().isNonnull() ? origL1EtMissRef()->gctEtHad() : nullptr;
+      auto* cand = dynamic_cast<const l1extra::L1EtMissParticle*>(origObjCand());
+      return cand ? cand->gctEtHad() : nullptr;
     };
     /// - Jet
-    const l1extra::L1JetParticleRef origL1JetRef() const;
     const L1GctJetCand* origL1GctJetCand() const {
-      return origL1JetRef().isNonnull() ? origL1JetRef()->gctJetCand() : nullptr;
+      auto* cand = dynamic_cast<const l1extra::L1JetParticle*>(origObjCand());
+      return cand ? cand->gctJetCand() : nullptr;
     };
     /// - Muon
-    const l1extra::L1MuonParticleRef origL1MuonRef() const;
     const L1MuGMTExtendedCand* origL1GmtMuonCand() const {
-      return origL1MuonRef().isNonnull() ? &(origL1MuonRef()->gmtMuonCand()) : nullptr;
+      auto* cand = dynamic_cast<const l1extra::L1MuonParticle*>(origObjCand());
+      return cand ? &(cand->gmtMuonCand()) : nullptr;
     };
 
     /// Special methods for the cut string parser

--- a/DataFormats/PatCandidates/src/Jet.cc
+++ b/DataFormats/PatCandidates/src/Jet.cc
@@ -366,8 +366,6 @@ const reco::BaseTagInfo* Jet::tagInfo(const std::string& label) const {
     if (tagInfoLabels_[i] == label) {
       if (!tagInfosFwdPtr_.empty())
         return tagInfosFwdPtr_[i].get();
-      else if (!tagInfos_.empty())
-        return &tagInfos_[i];
       return nullptr;
     }
   }

--- a/DataFormats/PatCandidates/src/TauPFSpecific.cc
+++ b/DataFormats/PatCandidates/src/TauPFSpecific.cc
@@ -1,10 +1,10 @@
 #include "DataFormats/PatCandidates/interface/TauPFSpecific.h"
-
+#include "DataFormats/Common/interface/RefToBaseToPtr.h"
 #include "DataFormats/JetReco/interface/Jet.h"
 
 pat::tau::TauPFSpecific::TauPFSpecific(const reco::PFTau& tau)
     :  // reference to PFJet from which PFTau was made
-      pfJetRef_(tau.jetRef()),
+      pfJetRef_(edm::refToBaseToPtr(tau.jetRef())),
       // Leading track/charged candidate
       leadPFChargedHadrCand_(tau.leadPFChargedHadrCand()),
       leadPFChargedHadrCandsignedSipt_(tau.leadPFChargedHadrCandsignedSipt()),

--- a/DataFormats/PatCandidates/src/TriggerObject.cc
+++ b/DataFormats/PatCandidates/src/TriggerObject.cc
@@ -3,6 +3,7 @@
 
 #include "DataFormats/PatCandidates/interface/TriggerObject.h"
 
+#include "DataFormats/Common/interface/RefToBaseToPtr.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 
 using namespace pat;
@@ -25,7 +26,7 @@ TriggerObject::TriggerObject(const reco::LeafCandidate& leafCand) : reco::LeafCa
 
 // Constructors from base candidate reference (for 'l1extra' particles)
 TriggerObject::TriggerObject(const reco::CandidateBaseRef& candRef)
-    : reco::LeafCandidate(*candRef), refToOrig_(candRef) {
+    : reco::LeafCandidate(*candRef), refToOrig_(edm::refToBaseToPtr(candRef)) {
   triggerObjectTypes_.clear();
 }
 
@@ -79,56 +80,3 @@ bool TriggerObject::hasTriggerObjectType(trigger::TriggerObjectType triggerObjec
   return false;
 }
 
-// Special methods for 'l1extra' particles
-
-// Getters specific to the 'l1extra' particle types
-// Exceptions of type 'edm::errors::InvalidReference' are thrown,
-// if wrong particle type is requested
-
-// EM
-const l1extra::L1EmParticleRef TriggerObject::origL1EmRef() const {
-  l1extra::L1EmParticleRef l1Ref;
-  try {
-    l1Ref = origObjRef().castTo<l1extra::L1EmParticleRef>();
-  } catch (edm::Exception const& X) {
-    if (X.categoryCode() != edm::errors::InvalidReference)
-      throw X;
-  }
-  return l1Ref;
-}
-
-// EtMiss
-const l1extra::L1EtMissParticleRef TriggerObject::origL1EtMissRef() const {
-  l1extra::L1EtMissParticleRef l1Ref;
-  try {
-    l1Ref = origObjRef().castTo<l1extra::L1EtMissParticleRef>();
-  } catch (edm::Exception const& X) {
-    if (X.categoryCode() != edm::errors::InvalidReference)
-      throw X;
-  }
-  return l1Ref;
-}
-
-// Jet
-const l1extra::L1JetParticleRef TriggerObject::origL1JetRef() const {
-  l1extra::L1JetParticleRef l1Ref;
-  try {
-    l1Ref = origObjRef().castTo<l1extra::L1JetParticleRef>();
-  } catch (edm::Exception const& X) {
-    if (X.categoryCode() != edm::errors::InvalidReference)
-      throw X;
-  }
-  return l1Ref;
-}
-
-// Muon
-const l1extra::L1MuonParticleRef TriggerObject::origL1MuonRef() const {
-  l1extra::L1MuonParticleRef l1Ref;
-  try {
-    l1Ref = origObjRef().castTo<l1extra::L1MuonParticleRef>();
-  } catch (edm::Exception const& X) {
-    if (X.categoryCode() != edm::errors::InvalidReference)
-      throw X;
-  }
-  return l1Ref;
-}

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -16,7 +16,8 @@
   <class name="pat::Lepton<reco::BaseTau>" />
 
   <!-- PAT Objects, and embedded data  -->
-  <class name="pat::Electron"  ClassVersion="38">
+  <class name="pat::Electron"  ClassVersion="39">
+   <version ClassVersion="39" checksum="1261966498"/>
    <version ClassVersion="38" checksum="1251314096"/>
    <version ClassVersion="37" checksum="4284869321"/>
    <version ClassVersion="36" checksum="199321903"/>
@@ -68,6 +69,7 @@
 
 
   <class name="pat::Muon"  ClassVersion="31">
+   <version ClassVersion="32" checksum="1891105271"/>
    <version ClassVersion="31" checksum="4230437113"/>
    <version ClassVersion="30" checksum="3276039509"/>
    <version ClassVersion="29" checksum="4221614933"/>
@@ -101,7 +103,8 @@
     <![CDATA[ cachedIP_ = onfile.cachedIP_[1] + 2*onfile.cachedIP_[2] + 4*onfile.cachedIP_[3] + 8*onfile.cachedIP_[4]; ]]>
   </ioread>
 
-  <class name="pat::Tau"  ClassVersion="19">
+  <class name="pat::Tau"  ClassVersion="20">
+   <version ClassVersion="20" checksum="183193665"/>
    <version ClassVersion="19" checksum="4141787547"/>
    <version ClassVersion="18" checksum="3279584614"/>
    <version ClassVersion="17" checksum="2561486007"/>
@@ -225,7 +228,8 @@
   </ioread>
 
   <class name="std::vector<pat::tau::TauPFEssential>" />
-  <class name="pat::Photon"  ClassVersion="22">
+  <class name="pat::Photon"  ClassVersion="23">
+   <version ClassVersion="23" checksum="953991574"/>
    <version ClassVersion="22" checksum="1415449268"/>
    <version ClassVersion="21" checksum="3263223164"/>
    <version ClassVersion="20" checksum="1579185367"/>
@@ -252,7 +256,8 @@
              newObj->setPflowIsolationVariables(pfIsoVar);]]>
   </ioread>
 
-  <class name="pat::Jet"  ClassVersion="17">
+  <class name="pat::Jet"  ClassVersion="18">
+   <version ClassVersion="18" checksum="2338023891"/>
    <version ClassVersion="17" checksum="739868501"/>
    <field name="daughtersTemp_" transient="true"/>
    <version ClassVersion="16" checksum="4069285947"/>
@@ -277,7 +282,8 @@
   <ioread sourceClass = "pat::Jet" version="[1-]" targetClass="pat::Jet" source="" target="daughtersTemp_">
     <![CDATA[daughtersTemp_.reset();]]>
   </ioread>
-  <class name="pat::MET"  ClassVersion="17">
+  <class name="pat::MET"  ClassVersion="18">
+   <version ClassVersion="18" checksum="3427850918"/>
     <version ClassVersion="17" checksum="1526897576"/>
     <version ClassVersion="16" checksum="2416242778"/>
     <field name="corMap_" transient="true"/>
@@ -300,18 +306,21 @@
    <version ClassVersion="11" checksum="2562213081"/>
    <version ClassVersion="10" checksum="2696169357"/>
   </class>
-  <class name="pat::Particle"  ClassVersion="12">
+  <class name="pat::Particle"  ClassVersion="13">
+   <version ClassVersion="13" checksum="1888859235"/>
    <version ClassVersion="12" checksum="1268816645"/>
    <version ClassVersion="11" checksum="2960540813"/>
    <version ClassVersion="10" checksum="1421351288"/>
   </class>
-  <class name="pat::CompositeCandidate"  ClassVersion="13">
+  <class name="pat::CompositeCandidate"  ClassVersion="14">
+   <version ClassVersion="14" checksum="3645592023"/>
    <version ClassVersion="13" checksum="1092859857"/>
    <version ClassVersion="12" checksum="2489375362"/>
    <version ClassVersion="11" checksum="3492108938"/>
    <version ClassVersion="10" checksum="417284221"/>
   </class>
-  <class name="pat::PFParticle"  ClassVersion="17">
+  <class name="pat::PFParticle"  ClassVersion="18">
+   <version ClassVersion="18" checksum="488797080"/>
    <version ClassVersion="17" checksum="3592543330"/>
    <version ClassVersion="16" checksum="4057492004"/>
    <version ClassVersion="15" checksum="1485536104"/>
@@ -321,7 +330,8 @@
    <version ClassVersion="11" checksum="2923110109"/>
    <version ClassVersion="10" checksum="2240381542"/>
   </class>
-  <class name="pat::GenericParticle"  ClassVersion="12">
+  <class name="pat::GenericParticle"  ClassVersion="13">
+   <version ClassVersion="13" checksum="1816929816"/>
    <version ClassVersion="12" checksum="3190464374"/>
    <version ClassVersion="11" checksum="4208136910"/>
    <version ClassVersion="10" checksum="3438694352"/>

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -312,7 +312,7 @@
    <version ClassVersion="10" checksum="417284221"/>
   </class>
   <class name="pat::PFParticle"  ClassVersion="17">
-   <version ClassVersion="17" checksum="677072585"/>
+   <version ClassVersion="17" checksum="3592543330"/>
    <version ClassVersion="16" checksum="4057492004"/>
    <version ClassVersion="15" checksum="1485536104"/>
    <version ClassVersion="14" checksum="2795911745"/>

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -174,7 +174,8 @@
   <ioread sourceClass="pat::Tau" targetClass="pat::Tau" version="[1-]" source="" target="isolationPFGammaCandsTransientPtrs_">
   <![CDATA[isolationPFGammaCandsTransientPtrs_.reset();]]>
   </ioread>
-  <class name="pat::tau::TauPFSpecific"  ClassVersion="16">
+  <class name="pat::tau::TauPFSpecific"  ClassVersion="17">
+   <version ClassVersion="17" checksum="2747567838"/>
    <version ClassVersion="16" checksum="443572625"/>
    <version ClassVersion="15" checksum="3425877587"/>
    <version ClassVersion="14" checksum="1401440164"/>
@@ -183,6 +184,12 @@
    <version ClassVersion="11" checksum="3975939304"/>
    <version ClassVersion="10" checksum="2617942038"/>
   </class>
+  <ioread sourceClass = "pat::tau::TauPFSpecific" version="[1-16]" targetClass="pat::tau::TauPFSpecific" source="edm::RefToBase<reco::Jet> pfJetRef_" target="pfJetRef_">
+   <![CDATA[
+     pfJetRef_ = edm::refToBaseToPtr_ioread(onfile.pfJetRef_);
+      ]]>
+  </ioread>
+
   <class name="std::vector<pat::tau::TauPFSpecific>" />
 
   <class name="pat::tau::TauPFEssential" ClassVersion="14">
@@ -256,7 +263,8 @@
              newObj->setPflowIsolationVariables(pfIsoVar);]]>
   </ioread>
 
-  <class name="pat::Jet"  ClassVersion="18">
+  <class name="pat::Jet"  ClassVersion="19">
+    <version ClassVersion="19" checksum="39535955"/>
    <version ClassVersion="18" checksum="2338023891"/>
    <version ClassVersion="17" checksum="739868501"/>
    <field name="daughtersTemp_" transient="true"/>

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -68,8 +68,8 @@
   </ioread>
 
 
-  <class name="pat::Muon"  ClassVersion="31">
-   <version ClassVersion="32" checksum="1891105271"/>
+  <class name="pat::Muon"  ClassVersion="32">
+   <version ClassVersion="32" checksum="2580925643"/>
    <version ClassVersion="31" checksum="4230437113"/>
    <version ClassVersion="30" checksum="3276039509"/>
    <version ClassVersion="29" checksum="4221614933"/>

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -305,12 +305,14 @@
    <version ClassVersion="11" checksum="2960540813"/>
    <version ClassVersion="10" checksum="1421351288"/>
   </class>
-  <class name="pat::CompositeCandidate"  ClassVersion="12">
+  <class name="pat::CompositeCandidate"  ClassVersion="13">
+   <version ClassVersion="13" checksum="1092859857"/>
    <version ClassVersion="12" checksum="2489375362"/>
    <version ClassVersion="11" checksum="3492108938"/>
    <version ClassVersion="10" checksum="417284221"/>
   </class>
-  <class name="pat::PFParticle"  ClassVersion="16">
+  <class name="pat::PFParticle"  ClassVersion="17">
+   <version ClassVersion="17" checksum="677072585"/>
    <version ClassVersion="16" checksum="4057492004"/>
    <version ClassVersion="15" checksum="1485536104"/>
    <version ClassVersion="14" checksum="2795911745"/>

--- a/DataFormats/PatCandidates/src/classes_def_trigger.xml
+++ b/DataFormats/PatCandidates/src/classes_def_trigger.xml
@@ -7,8 +7,8 @@
    <version ClassVersion="11" checksum="2574350865"/>
    <version ClassVersion="10" checksum="2299474032"/>
   </class>
-  <ioread sourceClass="pat::TriggerObject" version="[-12]" source="reco::CandidateBaseRef refToOrig_" targetClass="reco::CandidatePtr" target="refToOrig_">
-    <![CDATA[ refToOrig_ = edm::RefToBaseToPtr(onfile.refToOrig_); ]]>
+  <ioread sourceClass="pat::TriggerObject" version="[-12]" source="reco::CandidateBaseRef refToOrig_" targetClass="pat::TriggerObject" target="refToOrig_">
+    <![CDATA[ refToOrig_ = edm::refToBaseToPtr(onfile.refToOrig_); ]]>
    </ioread>
   <class name="std::vector&lt;pat::TriggerObject&gt;" />
   <class name="std::vector&lt;pat::TriggerObject&gt;::const_iterator" />

--- a/DataFormats/PatCandidates/src/classes_def_trigger.xml
+++ b/DataFormats/PatCandidates/src/classes_def_trigger.xml
@@ -8,7 +8,7 @@
    <version ClassVersion="10" checksum="2299474032"/>
   </class>
   <ioread sourceClass="pat::TriggerObject" version="[-12]" source="reco::CandidateBaseRef refToOrig_" targetClass="pat::TriggerObject" target="refToOrig_">
-    <![CDATA[ refToOrig_ = edm::refToBaseToPtr(onfile.refToOrig_); ]]>
+    <![CDATA[ refToOrig_ = edm::refToBaseToPtr_ioread(onfile.refToOrig_); ]]>
    </ioread>
   <class name="std::vector&lt;pat::TriggerObject&gt;" />
   <class name="std::vector&lt;pat::TriggerObject&gt;::const_iterator" />

--- a/DataFormats/PatCandidates/src/classes_def_trigger.xml
+++ b/DataFormats/PatCandidates/src/classes_def_trigger.xml
@@ -1,11 +1,15 @@
 <lcgdict>
  <selection>
 
-  <class name="pat::TriggerObject"  ClassVersion="12">
+  <class name="pat::TriggerObject"  ClassVersion="13">
+   <version ClassVersion="13" checksum="1564486686"/>
    <version ClassVersion="12" checksum="2628734905"/>
    <version ClassVersion="11" checksum="2574350865"/>
    <version ClassVersion="10" checksum="2299474032"/>
   </class>
+  <ioread sourceClass="pat::TriggerObject" version="[-12]" source="reco::CandidateBaseRef refToOrig_" targetClass="reco::CandidatePtr" target="refToOrig_">
+    <![CDATA[ refToOrig_ = edm::RefToBaseToPtr(onfile.refToOrig_); ]]>
+   </ioread>
   <class name="std::vector&lt;pat::TriggerObject&gt;" />
   <class name="std::vector&lt;pat::TriggerObject&gt;::const_iterator" />
   <class name="edm::Wrapper&lt;std::vector&lt;pat::TriggerObject&gt; &gt;" />
@@ -26,7 +30,8 @@
   <class name="std::map&lt;std::string, edm::RefProd&lt;edm::Association&lt;std::vector&lt;pat::TriggerObject&gt; &gt; &gt; &gt;::const_iterator" />
   <class name="edm::Wrapper&lt;std::map&lt;std::string, edm::RefProd&lt;edm::Association&lt;std::vector&lt;pat::TriggerObject&gt; &gt; &gt; &gt; &gt;" />
 
-  <class name="pat::TriggerObjectStandAlone"  ClassVersion="14">
+  <class name="pat::TriggerObjectStandAlone"  ClassVersion="15">
+   <version ClassVersion="15" checksum="3059129506"/>
    <version ClassVersion="14" checksum="2704342787"/>
    <version ClassVersion="13" checksum="54935316"/>
    <version ClassVersion="12" checksum="2923001116"/>

--- a/DataFormats/PatCandidates/src/classes_objects.h
+++ b/DataFormats/PatCandidates/src/classes_objects.h
@@ -4,6 +4,7 @@
 #include "DataFormats/Common/interface/Wrapper.h"
 #include "DataFormats/Common/interface/PtrVector.h"
 #include "DataFormats/Common/interface/FwdPtr.h"
+#include "DataFormats/Common/interface/RefToBaseToPtr_ioread.h"
 
 #include "DataFormats/PatCandidates/interface/Electron.h"
 #include "DataFormats/PatCandidates/interface/Muon.h"

--- a/DataFormats/PatCandidates/src/classes_trigger.h
+++ b/DataFormats/PatCandidates/src/classes_trigger.h
@@ -2,6 +2,7 @@
 #include "DataFormats/Common/interface/Association.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 #include "DataFormats/Common/interface/PtrVector.h"
+#include "DataFormats/Common/interface/RefToBaseToPtr.h"
 
 #include "DataFormats/PatCandidates/interface/TriggerObjectStandAlone.h"
 #include "DataFormats/PatCandidates/interface/TriggerEvent.h"

--- a/DataFormats/PatCandidates/src/classes_trigger.h
+++ b/DataFormats/PatCandidates/src/classes_trigger.h
@@ -2,7 +2,7 @@
 #include "DataFormats/Common/interface/Association.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 #include "DataFormats/Common/interface/PtrVector.h"
-#include "DataFormats/Common/interface/RefToBaseToPtr.h"
+#include "DataFormats/Common/interface/RefToBaseToPtr_ioread.h"
 
 #include "DataFormats/PatCandidates/interface/TriggerObjectStandAlone.h"
 #include "DataFormats/PatCandidates/interface/TriggerEvent.h"

--- a/DataFormats/RPCRecHit/interface/RPCRecHitCollection.h
+++ b/DataFormats/RPCRecHit/interface/RPCRecHitCollection.h
@@ -14,6 +14,13 @@
 #include "DataFormats/Common/interface/OwnVector.h"
 #include <functional>
 
+namespace edm::detail {
+  template<>
+    struct RangeMapContainer<edm::OwnVector<RPCRecHit>> {
+    using type = std::vector<RPCRecHit>;
+  };
+}
+
 typedef edm::RangeMap<RPCDetId, edm::OwnVector<RPCRecHit, edm::ClonePolicy<RPCRecHit> >, edm::ClonePolicy<RPCRecHit> >
     RPCRecHitCollection;
 

--- a/DataFormats/RecoCandidate/interface/IsoDeposit.h
+++ b/DataFormats/RecoCandidate/interface/IsoDeposit.h
@@ -25,7 +25,6 @@
 #include <vector>
 #include <algorithm>
 #include <typeinfo>
-#include <atomic>
 
 namespace reco {
   namespace isodeposit {
@@ -70,10 +69,10 @@ namespace reco {
 
     //! Constructor
     IsoDeposit(double eta = 0, double phi = 0);
-    IsoDeposit(const Direction& candDirection);
+    explicit IsoDeposit(const Direction& candDirection);
 
     //! Destructor
-    virtual ~IsoDeposit(){};
+    ~IsoDeposit(){};
 
     //! Get direction of isolation cone
     const Direction& direction() const { return theDirection; }
@@ -171,8 +170,8 @@ namespace reco {
           : parent_(parent), it_(it), cache_(), cacheReady_(false) {}
       const reco::IsoDeposit* parent_;
       IsoDeposit::DepositsMultimap::const_iterator it_;
-      CMS_THREAD_SAFE mutable Direction cache_;
-      mutable std::atomic<bool> cacheReady_;
+      CMS_SA_ALLOW mutable Direction cache_;
+      CMS_SA_ALLOW mutable bool cacheReady_;
     };
     const_iterator begin() const { return const_iterator(this, theDeposits.begin()); }
     const_iterator end() const { return const_iterator(this, theDeposits.end()); }

--- a/DataFormats/RecoCandidate/src/IsoDeposit.cc
+++ b/DataFormats/RecoCandidate/src/IsoDeposit.cc
@@ -18,12 +18,14 @@ IsoDeposit::IsoDeposit(double eta, double phi) : theDirection(Direction(eta, phi
 
 void IsoDeposit::addDeposit(double dr, double value) {
   Distance relDir = {float(dr), 0.f};
-  theDeposits.insert(std::make_pair(relDir, value));
+  theDeposits.insert(std::lower_bound(theDeposits.begin(), theDeposits.end(), relDir, Compare()),
+                     std::make_pair(relDir, value));
 }
 
 void IsoDeposit::addDeposit(const Direction& depDir, double deposit) {
   Distance relDir = depDir - theDirection;
-  theDeposits.insert(std::make_pair(relDir, deposit));
+  theDeposits.insert(std::lower_bound(theDeposits.begin(), theDeposits.end(), relDir, Compare()),
+                     std::make_pair(relDir, deposit));
 }
 
 double IsoDeposit::depositWithin(double coneSize, const Vetos& vetos, bool skipDepositVeto) const {
@@ -49,7 +51,7 @@ std::pair<double, int> IsoDeposit::depositAndCountWithin(double coneSize,
 
   Distance maxDistance = {float(coneSize), 999.f};
   typedef DepositsMultimap::const_iterator IM;
-  IM imLoc = theDeposits.upper_bound(maxDistance);
+  IM imLoc = std::upper_bound(theDeposits.begin(), theDeposits.end(), maxDistance, Compare());
   for (IM im = theDeposits.begin(); im != imLoc; ++im) {
     bool vetoed = false;
     for (IV iv = allVetos.begin(); iv < ivEnd; ++iv) {
@@ -107,7 +109,7 @@ std::pair<double, int> IsoDeposit::depositAndCountWithin(double coneSize,
 
   Distance maxDistance = {float(coneSize), 999.f};
   typedef DepositsMultimap::const_iterator IM;
-  IM imLoc = theDeposits.upper_bound(maxDistance);
+  IM imLoc = std::upper_bound(theDeposits.begin(), theDeposits.end(), maxDistance, Compare());
   for (IM im = theDeposits.begin(); im != imLoc; ++im) {
     bool vetoed = false;
     Direction dirDep = theDirection + im->first;
@@ -156,7 +158,7 @@ double IsoDeposit::nearestDR(double coneSize, const AbsVetos& vetos, bool skipDe
 
   Distance maxDistance = {float(coneSize), 999.f};
   typedef DepositsMultimap::const_iterator IM;
-  IM imLoc = theDeposits.upper_bound(maxDistance);
+  IM imLoc = std::upper_bound(theDeposits.begin(), theDeposits.end(), maxDistance, Compare());
   for (IM im = theDeposits.begin(); im != imLoc; ++im) {
     bool vetoed = false;
     Direction dirDep = theDirection + im->first;

--- a/DataFormats/RecoCandidate/src/classes_def.xml
+++ b/DataFormats/RecoCandidate/src/classes_def.xml
@@ -114,7 +114,8 @@
   <class name="edm::reftobase::VectorHolder<reco::Candidate, reco::RecoEcalCandidateRefVector>" />
   <class name="edm::reftobase::RefVectorHolder<reco::RecoEcalCandidateRefVector>" />
 
-  <class name="reco::IsoDeposit" ClassVersion="10">
+  <class name="reco::IsoDeposit" ClassVersion="11">
+   <version ClassVersion="11" checksum="3010914680"/>
    <version ClassVersion="10" checksum="2477314412"/>
   </class>
   <class name="reco::IsoDeposit::const_iterator" ClassVersion="10">

--- a/DataFormats/TauReco/src/classes_def_2.xml
+++ b/DataFormats/TauReco/src/classes_def_2.xml
@@ -344,7 +344,8 @@ isolationTauChargedHadronCandidates_.reset();
 <!-- </ioread> -->
 
 
-  <class name="reco::PFTauDecayMode" ClassVersion="13">
+  <class name="reco::PFTauDecayMode" ClassVersion="14">
+   <version ClassVersion="14" checksum="1040466571"/>
    <version ClassVersion="13" checksum="3507751092"/>
    <version ClassVersion="12" checksum="2043565930"/>
    <version ClassVersion="11" checksum="3414615810"/>

--- a/DataFormats/TrackReco/interface/Track.h
+++ b/DataFormats/TrackReco/interface/Track.h
@@ -152,7 +152,7 @@ namespace reco {
      *   Event, the reference may be invalid. Its validity should be tested,
      *   before the reference is actually used.
      */
-    const edm::RefToBase<TrajectorySeed>& seedRef() const { return extra_->seedRef(); }
+    const edm::Ptr<TrajectorySeed>& seedRef() const { return extra_->seedRef(); }
 
     /// get the residuals
     const TrackResiduals& residuals() const { return extra_->residuals(); }

--- a/DataFormats/TrackReco/interface/TrackExtra.h
+++ b/DataFormats/TrackReco/interface/TrackExtra.h
@@ -67,7 +67,7 @@ namespace reco {
                const CovarianceMatrix &innerState,
                unsigned int innerId,
                PropagationDirection seedDir,
-               edm::RefToBase<TrajectorySeed> seedRef = edm::RefToBase<TrajectorySeed>());
+               edm::Ptr<TrajectorySeed> seedRef = edm::Ptr<TrajectorySeed>());
 
     /// outermost hit position
     const Point &outerPosition() const { return outerPosition_; }
@@ -126,8 +126,8 @@ namespace reco {
      *   Event, the reference may be invalid. Its validity should be tested,
      *   before the reference is actually used.
      */
-    const edm::RefToBase<TrajectorySeed> &seedRef() const { return seedRef_; }
-    void setSeedRef(const edm::RefToBase<TrajectorySeed> &r) { seedRef_ = r; }
+    const edm::Ptr<TrajectorySeed> &seedRef() const { return seedRef_; }
+    void setSeedRef(const edm::Ptr<TrajectorySeed> &r) { seedRef_ = r; }
     /// set the residuals
     void setResiduals(const TrackResiduals &r) { trackResiduals_ = r; }
 
@@ -156,7 +156,7 @@ namespace reco {
     unsigned int innerDetId_;
 
     PropagationDirection seedDir_;
-    edm::RefToBase<TrajectorySeed> seedRef_;
+    edm::Ptr<TrajectorySeed> seedRef_;
 
     /// unbiased track residuals
     TrackResiduals trackResiduals_;

--- a/DataFormats/TrackReco/src/TrackExtra.cc
+++ b/DataFormats/TrackReco/src/TrackExtra.cc
@@ -14,7 +14,7 @@ TrackExtra::TrackExtra(const Point &outerPosition,
                        const CovarianceMatrix &innerCov,
                        unsigned int innerId,
                        PropagationDirection seedDir,
-                       edm::RefToBase<TrajectorySeed> seedRef)
+                       edm::Ptr<TrajectorySeed> seedRef)
     :
 
       TrackExtraBase(),

--- a/DataFormats/TrackReco/src/classes.h
+++ b/DataFormats/TrackReco/src/classes.h
@@ -17,6 +17,7 @@
 #include "DataFormats/Common/interface/OneToValue.h"
 #include "DataFormats/Common/interface/Ptr.h"
 #include "DataFormats/Common/interface/ValueMap.h"
+#include "DataFormats/Common/interface/RefToBaseToPtr_ioread.h"
 #include "DataFormats/TrackReco/interface/TrackToTrackMap.h"
 //#include "DataFormats/TrackReco/interface/DeDxHitFwd.h"
 #include "DataFormats/TrackReco/interface/DeDxHit.h"

--- a/DataFormats/TrackReco/src/classes_def.xml
+++ b/DataFormats/TrackReco/src/classes_def.xml
@@ -318,7 +318,8 @@
   </ioread>
 
 
-  <class name="reco::TrackExtra" ClassVersion="14">
+  <class name="reco::TrackExtra" ClassVersion="15">
+   <version ClassVersion="15" checksum="522273135"/>
    <version ClassVersion="14" checksum="388593738"/>
    <version ClassVersion="13" checksum="2526033150"/>
    <version ClassVersion="12" checksum="106004853"/>
@@ -329,6 +330,12 @@
     <field name="innerPosition_" iotype="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" /> 
     <field name="innerMomentum_" iotype="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" /> 
   </class>
+  <ioread sourceClass = "reco::TrackExtra" version="[1-14]" targetClass="reco::TrackExtra" source="edm::RefToBase<TrajectorySeed> seedRef_" target="seedRef_">
+   <![CDATA[
+     seedRef_ = edm::refToBaseToPtr_ioread(onfile.seedRef_);
+      ]]>
+  </ioread>
+
   <class name="std::vector<reco::TrackExtra>"/>
   <class name="edm::Wrapper<std::vector<reco::TrackExtra> >"/>
   <class name="edm::RefProd<std::vector<reco::TrackExtra> >"/>

--- a/DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h
@@ -5,6 +5,8 @@
 #include "DataFormats/DetId/interface/DetId.h"
 
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DataFormats/Common/interface/OwnVector.h"
+
 typedef edmNew::DetSetVector<SiPixelRecHit> SiPixelRecHitCollection;
 typedef SiPixelRecHitCollection SiPixelRecHitCollectionNew;
 

--- a/DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2DCollection.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2DCollection.h
@@ -8,6 +8,12 @@
 #include "DataFormats/Common/interface/OwnVector.h"
 #include <vector>
 
+namespace edm::detail {
+  template<>
+    struct RangeMapContainer<edm::OwnVector<SiStripMatchedRecHit2D>> {
+    using type = edm::OwnVector<SiStripMatchedRecHit2D>;
+  };
+}
 typedef edm::RangeMap<DetId, edm::OwnVector<SiStripMatchedRecHit2D> > SiStripMatchedRecHit2DCollectionOld;
 
 #include "DataFormats/Common/interface/DetSetVectorNew.h"

--- a/DataFormats/TrackerRecHit2D/interface/SiStripRecHit1DCollection.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiStripRecHit1DCollection.h
@@ -8,6 +8,12 @@
 #include "DataFormats/Common/interface/ClonePolicy.h"
 #include "DataFormats/Common/interface/OwnVector.h"
 
+namespace edm::detail {
+  template<>
+    struct RangeMapContainer<edm::OwnVector<SiStripRecHit1D>> {
+    using type = edm::OwnVector<SiStripRecHit1D>;
+  };
+}
 typedef edm::RangeMap<DetId, edm::OwnVector<SiStripRecHit1D> > SiStripRecHit1DCollectionOld;
 
 // new collection(for some far indetermined future)

--- a/DataFormats/TrackerRecHit2D/interface/SiStripRecHit2DCollection.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiStripRecHit2DCollection.h
@@ -8,6 +8,13 @@
 #include "DataFormats/Common/interface/ClonePolicy.h"
 #include "DataFormats/Common/interface/OwnVector.h"
 
+namespace edm::detail {
+  template<>
+    struct RangeMapContainer<edm::OwnVector<SiStripRecHit2D>> {
+    using type = edm::OwnVector<SiStripRecHit2D>;
+  };
+}
+
 typedef edm::RangeMap<DetId, edm::OwnVector<SiStripRecHit2D> > SiStripRecHit2DCollectionOld;
 
 // new collection(for some far indetermined future)

--- a/DataFormats/TrackerRecHit2D/src/classes.h
+++ b/DataFormats/TrackerRecHit2D/src/classes.h
@@ -31,4 +31,11 @@
 #include "DataFormats/TrackerRecHit2D/interface/VectorHit.h"
 #include <vector>
 
+namespace edm::detail {
+  template<>
+  struct RangeMapContainer<edm::OwnVector<SiPixelRecHit>> {
+    using type = edm::OwnVector<SiPixelRecHit>;
+  };
+}
+
 #endif  // SISTRIPRECHIT_CLASSES_H

--- a/DataFormats/V0Candidate/src/classes_def.xml
+++ b/DataFormats/V0Candidate/src/classes_def.xml
@@ -1,6 +1,7 @@
 <lcgdict>
 <selection>
-  <class name="reco::V0Candidate" ClassVersion="12">
+  <class name="reco::V0Candidate" ClassVersion="13">
+   <version ClassVersion="13" checksum="777041253"/>
    <version ClassVersion="12" checksum="3594667806"/>
    <version ClassVersion="11" checksum="3236778854"/>
    <version ClassVersion="10" checksum="1361748283"/>

--- a/DataFormats/VertexReco/interface/NuclearInteraction.h
+++ b/DataFormats/VertexReco/interface/NuclearInteraction.h
@@ -24,7 +24,7 @@ namespace reco {
     }
 
     /// return the base reference to the primary track
-    const edm::RefToBase<reco::Track>& primaryTrack() const { return *(vertex_.tracks_begin()); }
+    const edm::Ptr<reco::Track>& primaryTrack() const { return *(vertex_.tracks_begin()); }
 
     /// return the number of secondary tracks
     int secondaryTracksSize() const { return vertex_.tracksSize() - 1; }

--- a/DataFormats/VertexReco/interface/Vertex.h
+++ b/DataFormats/VertexReco/interface/Vertex.h
@@ -23,7 +23,7 @@
 #include "DataFormats/Math/interface/Point3D.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackReco/interface/Track.h"
-#include "DataFormats/Common/interface/RefToBase.h"
+#include "DataFormats/Common/interface/Ptr.h"
 #include <Math/GenVector/PxPyPzE4D.h>
 #include <Math/GenVector/PxPyPzM4D.h>
 #include "DataFormats/Math/interface/LorentzVector.h"
@@ -35,7 +35,7 @@ namespace reco {
   class Vertex {
   public:
     /// The iteratator for the vector<TrackRef>
-    typedef std::vector<TrackBaseRef>::const_iterator trackRef_iterator;
+    typedef std::vector<edm::Ptr<reco::Track>>::const_iterator trackRef_iterator;
     /// point in the space
     typedef math::XYZPoint Point;
     /// error matrix dimension
@@ -89,7 +89,7 @@ namespace reco {
       weights_.emplace_back(w * 255.f);
     }
     /// add the original a Track(reference) and the smoothed Track
-    void add(const TrackBaseRef &r, const Track &refTrack, float w = 1.0);
+    void add(const edm::Ptr<reco::Track> &r, const Track &refTrack, float w = 1.0);
     void removeTracks();
 
     ///returns the weight with which a Track has contributed to the vertex-fit.
@@ -112,7 +112,7 @@ namespace reco {
     /// number of tracks
     size_t tracksSize() const { return tracks_.size(); }
     /// python friendly track getting
-    const TrackBaseRef &trackRefAt(size_t idx) const { return tracks_[idx]; }
+    const edm::Ptr<reco::Track> &trackRefAt(size_t idx) const { return tracks_[idx]; }
     /// chi-squares
     double chi2() const { return chi2_; }
     /** Number of degrees of freedom
@@ -183,11 +183,11 @@ namespace reco {
 
     /// Returns the original track which corresponds to a particular refitted Track
     /// Throws an exception if now refitted tracks are stored ot the track is not found in the list
-    TrackBaseRef originalTrack(const Track &refTrack) const;
+    edm::Ptr<reco::Track> originalTrack(const Track &refTrack) const;
 
     /// Returns the refitted track which corresponds to a particular original Track
     /// Throws an exception if now refitted tracks are stored ot the track is not found in the list
-    Track refittedTrack(const TrackBaseRef &track) const;
+    Track refittedTrack(const edm::Ptr<reco::Track> &track) const;
 
     /// Returns the refitted track which corresponds to a particular original Track
     /// Throws an exception if now refitted tracks are stored ot the track is not found in the list
@@ -221,7 +221,7 @@ namespace reco {
     /// covariance matrix (4x4) as vector
     float covariance_[size4D];
     /// reference to tracks
-    std::vector<TrackBaseRef> tracks_;
+    std::vector<edm::Ptr<reco::Track>> tracks_;
     /// The vector of refitted tracks
     std::vector<Track> refittedTracks_;
     std::vector<uint8_t> weights_;

--- a/DataFormats/VertexReco/src/classes.h
+++ b/DataFormats/VertexReco/src/classes.h
@@ -8,6 +8,8 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/OneToManyWithQuality.h"
 #include "DataFormats/Common/interface/OneToManyWithQualityGeneric.h"
+#include "DataFormats/Common/interface/RefToBase.h"
+#include "DataFormats/Common/interface/RefToBaseToPtr_ioread.h"
 #include "DataFormats/Common/interface/View.h"
 
 #include "DataFormats/VertexReco/interface/Vertex.h"

--- a/DataFormats/VertexReco/src/classes_def.xml
+++ b/DataFormats/VertexReco/src/classes_def.xml
@@ -1,8 +1,17 @@
 <lcgdict>
-  <class name="reco::Vertex"  ClassVersion="11">
+  <class name="reco::Vertex"  ClassVersion="12">
+    <version ClassVersion="12" checksum="3100519676"/>
    <version ClassVersion="11" checksum="4120119845"/>
    <version ClassVersion="10" checksum="414871454"/>
   </class>
+<ioread sourceClass = "reco::Vertex" version="[1-11]" targetClass="reco::Vertex" source="std::vector<edm::RefToBase<reco::Track>> tracks_" target="tracks_">
+   <![CDATA[
+     tracks_.reserve(onfile.tracks_.size());
+     std::transform(onfile.tracks_.begin(), onfile.tracks_.end(), std::back_inserter(tracks_), [](auto const&r) {
+       return edm::refToBaseToPtr_ioread(r);
+     });
+      ]]>
+ </ioread>
   <class name="std::vector<reco::Vertex>" />
   <class name="edm::Wrapper<std::vector<reco::Vertex> >" />
   <class name="edm::Ref<std::vector<reco::Vertex>, reco::Vertex, edm::refhelper::FindUsingAdvance<std::vector<reco::Vertex>, reco::Vertex> >" />

--- a/FastSimDataFormats/External/interface/FastTrackerClusterCollection.h
+++ b/FastSimDataFormats/External/interface/FastTrackerClusterCollection.h
@@ -7,6 +7,13 @@
 #include "DataFormats/Common/interface/ClonePolicy.h"
 #include "DataFormats/Common/interface/OwnVector.h"
 
+namespace edm::detail {
+  template<>
+    struct RangeMapContainer<edm::OwnVector<FastTrackerCluster>> {
+    using type = edm::OwnVector<FastTrackerCluster>;
+  };
+}
+
 typedef edm::RangeMap<unsigned, edm::OwnVector<FastTrackerCluster> > FastTrackerClusterCollection;
 
 #endif

--- a/PhysicsTools/PatAlgos/plugins/PATJetSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATJetSlimmer.cc
@@ -106,7 +106,6 @@ void pat::PATJetSlimmer::produce(edm::Event& iEvent, const edm::EventSetup& iSet
 
     if (dropTagInfos_(*it)) {
       jet.tagInfoLabels_.clear();
-      jet.tagInfos_.clear();
       jet.tagInfosFwdPtr_.clear();
     }
     if (dropJetVars_(*it)) {

--- a/RecoMuon/MuonIdentification/src/MuonMesh.cc
+++ b/RecoMuon/MuonIdentification/src/MuonMesh.cc
@@ -297,12 +297,9 @@ void MuonMesh::pruneMesh() {
 bool MuonMesh::isDuplicateOf(const CSCSegmentRef& lhs, const CSCSegmentRef& rhs)
     const  // this isDuplicateOf() deals with duplicate segments in ME1/a
 {
-  bool result(false);
 
   if (!lhs->isME11a_duplicate())
-    return result;
-
-  std::vector<CSCSegment> lhs_duplicates = lhs->duplicateSegments();
+    return false;
 
   if (fabs(lhs->localPosition().x() - rhs->localPosition().x()) < 1E-3 &&
       fabs(lhs->localPosition().y() - rhs->localPosition().y()) < 1E-3 &&
@@ -314,35 +311,34 @@ bool MuonMesh::isDuplicateOf(const CSCSegmentRef& lhs, const CSCSegmentRef& rhs)
       fabs(lhs->localPositionError().yy() - rhs->localPositionError().yy()) < 1E-3 &&
       fabs(lhs->localDirectionError().xx() - rhs->localDirectionError().xx()) < 1E-3 &&
       fabs(lhs->localDirectionError().yy() - rhs->localDirectionError().yy()) < 1E-3)
-    result = true;
+    return true;
 
-  for (std::vector<CSCSegment>::const_iterator segIter1 = lhs_duplicates.begin(); segIter1 != lhs_duplicates.end();
-       ++segIter1) {  // loop over lhs duplicates
+  for (auto const& seg1 : lhs->duplicateSegments()) {
 
-    if (fabs(segIter1->localPosition().x() - rhs->localPosition().x()) < 1E-3 &&
-        fabs(segIter1->localPosition().y() - rhs->localPosition().y()) < 1E-3 &&
-        fabs(segIter1->localDirection().x() / segIter1->localDirection().z() -
+    if (fabs(seg1.localPosition().x() - rhs->localPosition().x()) < 1E-3 &&
+        fabs(seg1.localPosition().y() - rhs->localPosition().y()) < 1E-3 &&
+        fabs(seg1.localDirection().x() / seg1.localDirection().z() -
              rhs->localDirection().x() / rhs->localDirection().z()) < 1E-3 &&
-        fabs(segIter1->localDirection().y() / segIter1->localDirection().z() -
+        fabs(seg1.localDirection().y() / seg1.localDirection().z() -
              rhs->localDirection().y() / rhs->localDirection().z()) < 1E-3 &&
-        fabs(segIter1->localPositionError().xx() - rhs->localPositionError().xx()) < 1E-3 &&
-        fabs(segIter1->localPositionError().yy() - rhs->localPositionError().yy()) < 1E-3 &&
-        fabs(segIter1->localDirectionError().xx() - rhs->localDirectionError().xx()) < 1E-3 &&
-        fabs(segIter1->localDirectionError().yy() - rhs->localDirectionError().yy()) < 1E-3)
-      result = true;
+        fabs(seg1.localPositionError().xx() - rhs->localPositionError().xx()) < 1E-3 &&
+        fabs(seg1.localPositionError().yy() - rhs->localPositionError().yy()) < 1E-3 &&
+        fabs(seg1.localDirectionError().xx() - rhs->localDirectionError().xx()) < 1E-3 &&
+        fabs(seg1.localDirectionError().yy() - rhs->localDirectionError().yy()) < 1E-3)
+      return true;
     /*
-    if(fabs(segIter1->localPosition().x()        - rhs->localPosition().x()      ) < 2*sqrt(segIter1->localPositionError().xx()) &&
-       fabs(segIter1->localPosition().y()        - rhs->localPosition().y()      ) < 2*sqrt(segIter1->localPositionError().yy()) &&
-       fabs(segIter1->localDirection().x()/segIter1->localDirection().z()    - rhs->localDirection().x()/rhs->localDirection().z()   ) 
-       < 2*std::sqrt(std::max(segIter1->localDirectionError().yy(),rhs->localDirectionError().xx())) &&
-       fabs(segIter1->localDirection().y()/segIter1->localDirection().z()    - rhs->localDirection().y()/rhs->localDirection().z()   ) 
-       < 2*std::sqrt(std::max(segIter1->localDirectionError().yy(),rhs->localDirectionError().yy())))
+    if(fabs(seg1.localPosition().x()        - rhs->localPosition().x()      ) < 2*sqrt(seg1.localPositionError().xx()) &&
+       fabs(seg1.localPosition().y()        - rhs->localPosition().y()      ) < 2*sqrt(seg1.localPositionError().yy()) &&
+       fabs(seg1.localDirection().x()/seg1.localDirection().z()    - rhs->localDirection().x()/rhs->localDirection().z()   ) 
+       < 2*std::sqrt(std::max(seg1.localDirectionError().yy(),rhs->localDirectionError().xx())) &&
+       fabs(seg1.localDirection().y()/seg1.localDirection().z()    - rhs->localDirection().y()/rhs->localDirection().z()   ) 
+       < 2*std::sqrt(std::max(seg1.localDirectionError().yy(),rhs->localDirectionError().yy())))
       result = true;
     */
 
   }  // loop over duplicates
 
-  return result;
+  return false;
 }
 
 bool MuonMesh::isDuplicateOf(const std::pair<CSCDetId, CSCSegmentRef>& rhs,

--- a/TauAnalysis/MCEmbeddingTools/plugins/CollectionMerger.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/CollectionMerger.cc
@@ -20,6 +20,9 @@
 #include "DataFormats/Common/interface/RangeMap.h"
 #include "DataFormats/Common/interface/OwnVector.h"
 
+#include "DataFormats/DTRecHit/interface/DTRecHitCollection.h"
+#include "DataFormats/RPCRecHit/interface/RPCRecHitCollection.h"
+
 typedef CollectionMerger<edmNew::DetSetVector<SiPixelCluster>, SiPixelCluster> PixelColMerger;
 typedef CollectionMerger<edmNew::DetSetVector<SiStripCluster>, SiStripCluster> StripColMerger;
 

--- a/TauAnalysis/MCEmbeddingTools/plugins/MuonDetCleaner.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/MuonDetCleaner.cc
@@ -9,6 +9,9 @@
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
 #include "DataFormats/RPCRecHit/interface/RPCRecHit.h"
 
+#include "DataFormats/DTRecHit/interface/DTRecHitCollection.h"
+#include "DataFormats/RPCRecHit/interface/RPCRecHitCollection.h"
+
 typedef MuonDetCleaner<CSCDetId, CSCRecHit2D> CSCRecHitColCleaner;
 typedef MuonDetCleaner<DTLayerId, DTRecHit1DPair> DTRecHitColCleaner;
 typedef MuonDetCleaner<RPCDetId, RPCRecHit> RPCRecHitColCleaner;


### PR DESCRIPTION
- hacked RangeMap so that the template argument does NOT have to match the actual type used for storage. This allowed simpler scheme evolution by avoiding changing the type of the data product.
- Converted edm::RefToBase used in miniAOD to edm::Ptr
- hacked CompositeCandidate so it no longer has any data members. This avoids the scheme evolution problem where we can't drop a base class from the inheritance hierarchy (which we want to do for PFCandidate).
- Avoid recursive class use in CSCSegment
- removed user data products from PATObject to avoid problem with polymorphism
- removed std::multimap usage